### PR TITLE
fix #36 missing rc-collapse-item-active classname on active panel header

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 # History
 ----
 
+## 1.6.5
+
+- fix missing rc-collapse-item-active classname on active panel header 
+
 ## 1.6.0
 
 - lazy render/controllable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-collapse",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "rc-collapse ui component for react",
   "keywords": [
     "react",

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 import PanelContent from './PanelContent';
 import Animate from 'rc-animate';
 
@@ -31,8 +32,12 @@ const CollapsePanel = React.createClass({
   render() {
     const { prefixCls, header, children, isActive } = this.props;
     const headerCls = `${prefixCls}-header`;
+    const itemCls = classNames({
+      [`${prefixCls}-item`]: true,
+      [`${prefixCls}-item-active`]: isActive,
+    });
     return (
-      <div className={`${prefixCls}-item`}>
+      <div className={ itemCls }>
         <div
           className={headerCls}
           onClick={this.handleItemClick}

--- a/tests/index.js
+++ b/tests/index.js
@@ -106,15 +106,21 @@ describe('collapse', () => {
       expect(findDOMNode(collapse, 'rc-collapse-content-active').length).to.be(0);
     });
 
+    it('accordion item, should default open zero item', () => {
+      expect(findDOMNode(collapse, 'rc-collapse-item-active').length).to.be(0);
+    });
+
     it('should toggle show on panel', (done) => {
       let header = findDOMNode(collapse, 'rc-collapse-header')[1];
       Simulate.click(header);
       setTimeout(() => {
         expect(findDOMNode(collapse, 'rc-collapse-content-active').length).to.be(1);
+        expect(findDOMNode(collapse, 'rc-collapse-item-active').length).to.be(1);
         header = findDOMNode(collapse, 'rc-collapse-header')[1];
         Simulate.click(header);
         setTimeout(() => {
           expect(findDOMNode(collapse, 'rc-collapse-content-active').length).to.be(0);
+          expect(findDOMNode(collapse, 'rc-collapse-item-active').length).to.be(0);
           done();
         }, 500);
       }, 500);
@@ -125,11 +131,13 @@ describe('collapse', () => {
       Simulate.click(header);
       setTimeout(() => {
         expect(findDOMNode(collapse, 'rc-collapse-content-active').length).to.be(1);
+        expect(findDOMNode(collapse, 'rc-collapse-item-active').length).to.be(1);
         header = findDOMNode(collapse, 'rc-collapse-header')[2];
         Simulate.click(header);
 
         setTimeout(() => {
           expect(findDOMNode(collapse, 'rc-collapse-content-active').length).to.be(1);
+          expect(findDOMNode(collapse, 'rc-collapse-item-active').length).to.be(1);
           done();
         }, 500);
       }, 500);


### PR DESCRIPTION
```rc-collapse-item-active classname``` was not added to the active panel header