### PR TITLE
Remove PanelContent from DOM if it's Panel inactive

### DIFF
--- a/src/PanelContent.jsx
+++ b/src/PanelContent.jsx
@@ -26,7 +26,7 @@ const PanelContent = React.createClass({
         className={contentCls}
         role="tabpanel"
       >
-        <div className={`${prefixCls}-content-box`}>{children}</div>
+	{isActive?<div className={`${prefixCls}-content-box`}>{children}</div>: null}
       </div>
     );
   },


### PR DESCRIPTION
Make rendering of div element, containeing children dependent on Panel `isActive` flag.
Fixing #43 issue.