### PR TITLE
Add 'showArrow' prop to Panel to toggle arrow visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ item.
           <th></th>
           <td>header content of Panel</td>
       </tr>
+      <tr>
+          <td>showArrow</td>
+          <td>boolean</td>
+          <th>true</th>
+          <td>show arrow beside header</td>
+      </tr>
        <tr>
             <td>className</td>
             <td>String or object</td>

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -17,12 +17,14 @@ const CollapsePanel = React.createClass({
       PropTypes.number,
       PropTypes.node,
     ]),
+    showArrow: PropTypes.bool,
     isActive: PropTypes.bool,
     onItemClick: PropTypes.func,
   },
 
   getDefaultProps() {
     return {
+      showArrow: true,
       isActive: false,
       onItemClick() {
       },
@@ -34,7 +36,7 @@ const CollapsePanel = React.createClass({
   },
 
   render() {
-    const { className, prefixCls, header, children, isActive } = this.props;
+    const { className, prefixCls, header, children, isActive, showArrow } = this.props;
     const headerCls = `${prefixCls}-header`;
     const itemCls = classNames({
       [`${prefixCls}-item`]: true,
@@ -49,7 +51,7 @@ const CollapsePanel = React.createClass({
           role="tab"
           aria-expanded={isActive}
         >
-          <i className="arrow"></i>
+          {showArrow && <i className="arrow"></i>}
           {header}
         </div>
         <Animate


### PR DESCRIPTION
Hello, I would like to add a 'showArrow' prop to the Panel component to be able to handle the visibility of the small arrow beside the Header. I would like the ability to hide the arrow when passing in my own component as the Header. Please let me know if you have any questions, thanks!