### PR TITLE
Fix deprecation warnings for react >= 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   ],
   "dependencies": {
     "classnames": "2.x",
+    "create-react-class": "^15.5.1",
     "css-animation": "1.x",
     "prop-types": "^15.5.6",
     "rc-animate": "2.x"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   ],
   "dependencies": {
     "classnames": "2.x",
-    "create-react-class": "^15.5.1",
     "css-animation": "1.x",
     "prop-types": "^15.5.6",
     "rc-animate": "2.x"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   ],
   "dependencies": {
     "classnames": "2.x",
-    "rc-animate": "2.x",
-    "css-animation": "1.x"
+    "css-animation": "1.x",
+    "prop-types": "^15.5.6",
+    "rc-animate": "2.x"
   }
 }

--- a/src/Collapse.jsx
+++ b/src/Collapse.jsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 import CollapsePanel from './Panel';
 import openAnimationFactory from './openAnimationFactory';
@@ -12,50 +12,21 @@ function toArray(activeKey) {
   return currentActiveKey;
 }
 
-const createReactClass = require('create-react-class');
-const Collapse = createReactClass({
-  propTypes: {
-    children: PropTypes.any,
-    prefixCls: PropTypes.string,
-    activeKey: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    defaultActiveKey: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    openAnimation: PropTypes.object,
-    onChange: PropTypes.func,
-    accordion: PropTypes.bool,
-    className: PropTypes.string,
-    style: PropTypes.object,
-  },
+class Collapse extends Component {
+  constructor(props) {
+    super(props);
 
-  statics: {
-    Panel: CollapsePanel,
-  },
-
-  getDefaultProps() {
-    return {
-      prefixCls: 'rc-collapse',
-      onChange() {
-      },
-      accordion: false,
-    };
-  },
-
-  getInitialState() {
     const { activeKey, defaultActiveKey } = this.props;
     let currentActiveKey = defaultActiveKey;
     if ('activeKey' in this.props) {
       currentActiveKey = activeKey;
     }
-    return {
+
+    this.state = {
       openAnimation: this.props.openAnimation || openAnimationFactory(this.props.prefixCls),
       activeKey: toArray(currentActiveKey),
     };
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if ('activeKey' in nextProps) {
@@ -68,7 +39,7 @@ const Collapse = createReactClass({
         openAnimation: nextProps.openAnimation,
       });
     }
-  },
+  }
 
   onClickItem(key) {
     return () => {
@@ -88,7 +59,7 @@ const Collapse = createReactClass({
       }
       this.setActiveKey(activeKey);
     };
-  },
+  }
 
   getItems() {
     const activeKey = this.state.activeKey;
@@ -121,14 +92,14 @@ const Collapse = createReactClass({
     });
 
     return newChildren;
-  },
+  }
 
   setActiveKey(activeKey) {
     if (!('activeKey' in this.props)) {
       this.setState({ activeKey });
     }
     this.props.onChange(this.props.accordion ? activeKey[0] : activeKey);
-  },
+  }
 
   render() {
     const { prefixCls, className, style } = this.props;
@@ -141,7 +112,33 @@ const Collapse = createReactClass({
         {this.getItems()}
       </div>
     );
-  },
-});
+  }
+}
+
+Collapse.propTypes = {
+  children: PropTypes.any,
+  prefixCls: PropTypes.string,
+  activeKey: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+  defaultActiveKey: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+  openAnimation: PropTypes.object,
+  onChange: PropTypes.func,
+  accordion: PropTypes.bool,
+  className: PropTypes.string,
+  style: PropTypes.object,
+};
+
+Collapse.defaultProps = {
+  prefixCls: 'rc-collapse',
+  onChange() {},
+  accordion: false,
+};
+
+Collapse.Panel = CollapsePanel;
 
 export default Collapse;

--- a/src/Collapse.jsx
+++ b/src/Collapse.jsx
@@ -12,7 +12,8 @@ function toArray(activeKey) {
   return currentActiveKey;
 }
 
-const Collapse = React.createClass({
+const createReactClass = require('create-react-class');
+const Collapse = createReactClass({
   propTypes: {
     children: PropTypes.any,
     prefixCls: PropTypes.string,

--- a/src/Collapse.jsx
+++ b/src/Collapse.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Children }from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 import CollapsePanel from './Panel';
 import openAnimationFactory from './openAnimationFactory';
 import classNames from 'classnames';

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 import PanelContent from './PanelContent';
 import Animate from 'rc-animate';
 
-const CollapsePanel = React.createClass({
+const createReactClass = require('create-react-class');
+const CollapsePanel = createReactClass({
   propTypes: {
     className: PropTypes.oneOfType([
       PropTypes.string,

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -1,42 +1,13 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import PanelContent from './PanelContent';
 import Animate from 'rc-animate';
 
-const createReactClass = require('create-react-class');
-const CollapsePanel = createReactClass({
-  propTypes: {
-    className: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-    ]),
-    children: PropTypes.any,
-    openAnimation: PropTypes.object,
-    prefixCls: PropTypes.string,
-    header: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.node,
-    ]),
-    showArrow: PropTypes.bool,
-    isActive: PropTypes.bool,
-    onItemClick: PropTypes.func,
-    style: PropTypes.object,
-  },
-
-  getDefaultProps() {
-    return {
-      showArrow: true,
-      isActive: false,
-      onItemClick() {
-      },
-    };
-  },
-
+class CollapsePanel extends Component {
   handleItemClick() {
     this.props.onItemClick();
-  },
+  }
 
   render() {
     const { className, style, prefixCls, header, children, isActive, showArrow } = this.props;
@@ -49,7 +20,7 @@ const CollapsePanel = createReactClass({
       <div className={itemCls} style={style}>
         <div
           className={headerCls}
-          onClick={this.handleItemClick}
+          onClick={this.handleItemClick.bind(this)}
           role="tab"
           aria-expanded={isActive}
         >
@@ -68,7 +39,32 @@ const CollapsePanel = createReactClass({
         </Animate>
       </div>
     );
-  },
-});
+  }
+}
+
+CollapsePanel.propTypes = {
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]),
+  children: PropTypes.any,
+  openAnimation: PropTypes.object,
+  prefixCls: PropTypes.string,
+  header: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.node,
+  ]),
+  showArrow: PropTypes.bool,
+  isActive: PropTypes.bool,
+  onItemClick: PropTypes.func,
+  style: PropTypes.object,
+};
+
+CollapsePanel.defaultProps = {
+  showArrow: true,
+  isActive: false,
+  onItemClick() {},
+};
 
 export default CollapsePanel;

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import PanelContent from './PanelContent';
 import Animate from 'rc-animate';

--- a/src/PanelContent.jsx
+++ b/src/PanelContent.jsx
@@ -1,17 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const createReactClass = require('create-react-class');
-const PanelContent = createReactClass({
-  propTypes: {
-    prefixCls: PropTypes.string,
-    isActive: PropTypes.bool,
-    children: PropTypes.any,
-  },
+class PanelContent extends Component {
   shouldComponentUpdate(nextProps) {
     return this.props.isActive || nextProps.isActive;
-  },
+  }
+
   render() {
     this._isActived = this._isActived || this.props.isActive;
     if (!this._isActived) {
@@ -31,7 +26,13 @@ const PanelContent = createReactClass({
         <div className={`${prefixCls}-content-box`}>{children}</div>
       </div>
     );
-  },
-});
+  }
+}
+
+PanelContent.propTypes = {
+  prefixCls: PropTypes.string,
+  isActive: PropTypes.bool,
+  children: PropTypes.any,
+};
 
 export default PanelContent;

--- a/src/PanelContent.jsx
+++ b/src/PanelContent.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-const PanelContent = React.createClass({
+const createReactClass = require('create-react-class');
+const PanelContent = createReactClass({
   propTypes: {
     prefixCls: PropTypes.string,
     isActive: PropTypes.bool,

--- a/src/PanelContent.jsx
+++ b/src/PanelContent.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const PanelContent = React.createClass({


### PR DESCRIPTION
Hi.

In React v15.5.0, `React.PropTypes` and `React.createClass` became deprecate.
So I migrated to `prop-types` package and `create-react-class`  package.

