### PR TITLE
Add className prop to Collapse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ ReactDOM.render(collapse, container);
           <td>current active Panel key</td>
       </tr>
       <tr>
+        <td>className</td>
+        <td>String or object</td>
+        <th></th>
+        <td>custom className to apply</td>
+      </tr>
+      <tr>
           <td>defaultActiveKey</td>
           <td>String|Array<String></td>
           <th>null</th>


### PR DESCRIPTION
I added `className` to the documentation of the Collapse API since it was suggested in issue #54 after our team assumed that Collapse could not receive this parameter.