### PR TITLE
Allow user to add custom header classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ require('rc-collapse/assets/index.css');
 
 var collapse = (
   <Collapse accordion={true}>
-    <Panel header="hello">this is panel content</Panel>
+    <Panel header="hello" headerClass="my-header-class">this is panel content</Panel>
     <Panel header="title2">this is panel content2 or other</Panel>
   </Collapse>
 );
@@ -137,6 +137,12 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
           <td>String or node</td>
           <th></th>
           <td>header content of Panel</td>
+      </tr>
+      <tr>
+          <td>headerClass</td>
+          <td>String</td>
+          <th>' '</th>
+          <td>custom className to apply to header</td>
       </tr>
       <tr>
           <td>showArrow</td>

--- a/src/Collapse.jsx
+++ b/src/Collapse.jsx
@@ -71,6 +71,7 @@ class Collapse extends Component {
       // If there is no key provide, use the panel order as default key
       const key = child.key || String(index);
       const header = child.props.header;
+      const headerClass = child.props.headerClass;
       let isActive = false;
       if (accordion) {
         isActive = activeKey[0] === key;
@@ -81,6 +82,7 @@ class Collapse extends Component {
       const props = {
         key,
         header,
+        headerClass,
         isActive,
         prefixCls,
         destroyInactivePanel,

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -15,12 +15,13 @@ class CollapsePanel extends Component {
       style,
       prefixCls,
       header,
+      headerClass,
       children,
       isActive,
       showArrow,
       destroyInactivePanel,
     } = this.props;
-    const headerCls = `${prefixCls}-header`;
+    const headerCls = `${prefixCls}-header ${headerClass}`;
     const itemCls = classNames({
       [`${prefixCls}-item`]: true,
       [`${prefixCls}-item-active`]: isActive,
@@ -68,6 +69,7 @@ CollapsePanel.propTypes = {
     PropTypes.number,
     PropTypes.node,
   ]),
+  headerClass: PropTypes.string,
   showArrow: PropTypes.bool,
   isActive: PropTypes.bool,
   onItemClick: PropTypes.func,
@@ -80,6 +82,7 @@ CollapsePanel.defaultProps = {
   isActive: false,
   destroyInactivePanel: false,
   onItemClick() {},
+  headerClass: '',
 };
 
 export default CollapsePanel;


### PR DESCRIPTION
I need to add custom styles to the header where I'm using this component, and realised that others may be likely to want to do the same. Therefore, I've added in a new prop, headerClass, to allow users to add customer header styles to this area of the component.

Thanks for creating an awesome component, and please let me know if I've missed anything out! :)