### PR TITLE
fix(WAI-ARIA): make aria-expanded prop valid in preact

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 # History
 ----
 
+## 1.9.1 2018-05-10
+
+- Fix invalid aria-expanded prop in preact
+
 ## 1.9.0 2018-04-02
 
 - Add keyboard support [#84](https://github.com/react-component/collapse/pull/84)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-collapse",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "rc-collapse ui component for react",
   "keywords": [
     "react",

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -49,7 +49,7 @@ class CollapsePanel extends Component {
           onClick={this.handleItemClick}
           role={accordion ? 'tab' : 'button'}
           tabIndex={disabled ? -1 : 0}
-          aria-expanded={isActive}
+          aria-expanded={`${isActive}`}
           onKeyPress={this.handleKeyPress}
         >
           {showArrow && <i className="arrow" />}


### PR DESCRIPTION
Preact will ignore the prop which value is boolean false
Convert the value to string can avoid this problem