### PR TITLE
Fix ant-design/ant-design#11279

### DIFF
--- a/src/PanelContent.jsx
+++ b/src/PanelContent.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 
 class PanelContent extends Component {
   shouldComponentUpdate(nextProps) {
-    return this.props.isActive || nextProps.isActive;
+    return this.props.forceRender || this.props.isActive || nextProps.isActive;
   }
 
   render() {


### PR DESCRIPTION
修复 Collapse 在 props 改变时未及时渲染的问题  
Panel 在设置了 forceRender=true 后即使未被展开也应该更新