### PR TITLE
fix inherited bug

### DIFF
--- a/src/Collapse.jsx
+++ b/src/Collapse.jsx
@@ -17,14 +17,14 @@ class Collapse extends Component {
   constructor(props) {
     super(props);
 
-    const { activeKey, defaultActiveKey } = this.props;
+    const { activeKey, defaultActiveKey } = props;
     let currentActiveKey = defaultActiveKey;
-    if ('activeKey' in this.props) {
+    if ('activeKey' in props) {
       currentActiveKey = activeKey;
     }
 
     this.state = {
-      openAnimation: this.props.openAnimation || openAnimationFactory(this.props.prefixCls),
+      openAnimation: props.openAnimation || openAnimationFactory(props.prefixCls),
       activeKey: toArray(currentActiveKey),
     };
   }


### PR DESCRIPTION
use `this.props.xxx` in `constructor` will lead to a bug in ie9 and ie10.

it is because of inheritance.

If there are no other questions，please merge as soon as possible.