### PR TITLE
Add support for contentClass prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
           <td>custom className to apply to header</td>
       </tr>
       <tr>
+          <td>contentClass</td>
+          <td>String</td>
+          <th>' '</th>
+          <td>custom className to apply to content</td>
+      </tr>
+      <tr>
           <td>showArrow</td>
           <td>boolean</td>
           <th>true</th>

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -13,6 +13,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
     destroyInactivePanel: false,
     onItemClick() {},
     headerClass: '',
+    contentClass: '',
     forceRender: false,
   };
 
@@ -42,6 +43,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       prefixCls,
       header,
       headerClass,
+      contentClass,
       children,
       isActive,
       showArrow,
@@ -85,6 +87,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
         </div>
         <Animate showProp="isActive" exclusive component="" animation={this.props.openAnimation}>
           <PanelContent
+            contentClass={contentClass}
             prefixCls={prefixCls}
             isActive={isActive}
             destroyInactivePanel={destroyInactivePanel}

--- a/src/PanelContent.tsx
+++ b/src/PanelContent.tsx
@@ -18,11 +18,20 @@ class PanelContent extends React.Component<CollapsePanelProps, any> {
     if (!this._isActived) {
       return null;
     }
-    const { prefixCls, isActive, children, destroyInactivePanel, forceRender, role } = this.props;
+    const {
+      prefixCls,
+      contentClass,
+      isActive,
+      children,
+      destroyInactivePanel,
+      forceRender,
+      role,
+    } = this.props;
 
     const contentCls = classnames(`${prefixCls}-content`, {
       [`${prefixCls}-content-active`]: isActive,
       [`${prefixCls}-content-inactive`]: !isActive,
+      [contentClass]: contentClass,
     });
 
     const child =

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -23,6 +23,7 @@ export interface CollapsePanelProps {
   header?: string | React.ReactNode;
   prefixCls?: string;
   headerClass?: string;
+  contentClass?: string;
   showArrow?: boolean;
   className?: string;
   style?: object;


### PR DESCRIPTION
## Background
- I've recently run into some issues with the content component where I am unable to set `overflow: visible` on the div and an absolute div inside is getting cut off. I need to be able to pass a className to the content container, it doesnt work to just set the style on the main Panel div.

## Changes
- Add support for `contentClass` prop

## Tests
- [x] Existing unit tests pass