### PR TITLE
chore: support collapsable、 remove disabled of panel and headerCollapsableOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
     </tbody>
 </table>
 
-> `disabled` is removed since 3.0.0, please use `collapsable` replace it.
+> `disabled` is removed since 3.0.0, please use `collapsable=false` replace it.
 
 #### key
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ ReactDOM.render(collapse, container);
           <td>specific the custom expand icon.</td>
       </tr>
       <tr>
-          <td>collapsable</td>
+          <td>collapsible</td>
           <td>Boolean | 'header'</td>
           <th>true</th>
-          <td>specify whether the panel of children is collapsable or the area of collapsable.</td>
+          <td>specify whether the panel of children is collapsible or the area of collapsible.</td>
       </tr>
     </tbody>
 </table>
@@ -186,7 +186,7 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
         <td>disabled</td>
         <td>boolean</td>
         <th>false</th>
-        <td>whether the panel is collapsable</td>
+        <td>whether the panel is collapsible</td>
       </tr>
       <tr>
         <td>forceRender</td>
@@ -201,15 +201,15 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
           <td>Content to render in the right of the panel header</td>
       </tr>
       <tr>
-          <td>collapsable</td>
+          <td>collapsible</td>
           <td>Boolean | 'header'</td>
           <th>true</th>
-          <td>specify whether the panel be collapsable or the area of collapsable.</td>
+          <td>specify whether the panel be collapsible or the area of collapsible.</td>
       </tr>
     </tbody>
 </table>
 
-> `disabled` is removed since 3.0.0, please use `collapsable=false` replace it.
+> `disabled` is removed since 3.0.0, please use `collapsible=false` replace it.
 
 #### key
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ ReactDOM.render(collapse, container);
           <th></th>
           <td>specific the custom expand icon.</td>
       </tr>
+      <tr>
+          <td>collapsable</td>
+          <td>Boolean | 'header'</td>
+          <th>true</th>
+          <td>specify whether the panel of children is collapsable or the area of collapsable.</td>
+      </tr>
     </tbody>
 </table>
 
@@ -180,7 +186,7 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
         <td>disabled</td>
         <td>boolean</td>
         <th>false</th>
-        <td>whether the panel is collapsible</td>
+        <td>whether the panel is collapsable</td>
       </tr>
       <tr>
         <td>forceRender</td>
@@ -194,8 +200,16 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
           <th></th>
           <td>Content to render in the right of the panel header</td>
       </tr>
+      <tr>
+          <td>collapsable</td>
+          <td>Boolean | 'header'</td>
+          <th>true</th>
+          <td>specify whether the panel be collapsable or the area of collapsable.</td>
+      </tr>
     </tbody>
 </table>
+
+> `disabled` is removed since 3.0.0, please use `collapsable` replace it.
 
 #### key
 

--- a/assets/index.less
+++ b/assets/index.less
@@ -59,7 +59,7 @@
         margin: 0 16px 0 auto;
       }
     }
-    .@{prefixCls}-header-collapsable-only {
+    .@{prefixCls}-header-collapsible-only {
       cursor: default;
       .@{prefixCls}-header-text {
         cursor: pointer;

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -18,7 +18,7 @@ class Test extends React.Component {
     time: random(),
     accordion: false,
     activeKey: ['4'],
-    collapsable: true,
+    collapsible: true,
   };
 
   onChange = (activeKey: string) => {
@@ -33,7 +33,11 @@ class Test extends React.Component {
     for (let i = 0, len = 3; i < len; i++) {
       const key = i + 1;
       items.push(
-        <Panel header={`This is panel header ${key}`} key={key} disabled={i === 0}>
+        <Panel
+          header={`This is panel header ${key}`}
+          key={key}
+          collapsible={i === 0 ? false : undefined}
+        >
           <p>{text.repeat(this.state.time)}</p>
         </Panel>,
       );
@@ -89,15 +93,15 @@ class Test extends React.Component {
     });
   };
 
-  handleCollapsableChange = (e: any) => {
+  handleCollapsibleChange = (e: any) => {
     const values = [true, 'header', false];
     this.setState({
-      collapsable: values[e.target.value],
+      collapsible: values[e.target.value],
     });
   };
 
   render() {
-    const { accordion, activeKey, collapsable } = this.state;
+    const { accordion, activeKey, collapsible } = this.state;
     const btn = accordion ? 'Mode: accordion' : 'Mode: collapse';
     return (
       <div style={{ margin: 20, width: 400 }}>
@@ -108,8 +112,8 @@ class Test extends React.Component {
           {btn}
         </button>
         <p>
-          collapsable:
-          <select onChange={this.handleCollapsableChange}>
+          collapsible:
+          <select onChange={this.handleCollapsibleChange}>
             <option value={0}>true</option>
             <option value={1}>header</option>
             <option value={2}>false</option>
@@ -123,7 +127,7 @@ class Test extends React.Component {
         <br />
         <br />
         <Collapse
-          collapsable={collapsable}
+          collapsible={collapsible}
           accordion={accordion}
           onChange={this.onChange}
           activeKey={activeKey}

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -18,7 +18,7 @@ class Test extends React.Component {
     time: random(),
     accordion: false,
     activeKey: ['4'],
-    headerCollapsableOnly: false,
+    collapsable: true,
   };
 
   onChange = (activeKey: string) => {
@@ -89,19 +89,16 @@ class Test extends React.Component {
     });
   };
 
-  toggleHeaderCollapsableOnly = () => {
-    const { headerCollapsableOnly } = this.state;
+  handleCollapsableChange = (e: any) => {
+    const values = [true, 'header', false];
     this.setState({
-      headerCollapsableOnly: !headerCollapsableOnly,
+      collapsable: values[e.target.value],
     });
   };
 
   render() {
-    const { accordion, activeKey, headerCollapsableOnly } = this.state;
+    const { accordion, activeKey, collapsable } = this.state;
     const btn = accordion ? 'Mode: accordion' : 'Mode: collapse';
-    const headerCollapsableOnlyBtn = headerCollapsableOnly
-      ? 'headerCollapsableOnly: true'
-      : 'headerCollapsableOnly: false';
     return (
       <div style={{ margin: 20, width: 400 }}>
         <button type="button" onClick={this.reRender}>
@@ -110,9 +107,14 @@ class Test extends React.Component {
         <button type="button" onClick={this.toggle}>
           {btn}
         </button>
-        <button type="button" onClick={this.toggleHeaderCollapsableOnly}>
-          {headerCollapsableOnlyBtn}
-        </button>
+        <p>
+          collapsable:
+          <select onChange={this.handleCollapsableChange}>
+            <option value={0}>true</option>
+            <option value={1}>header</option>
+            <option value={2}>false</option>
+          </select>
+        </p>
         <br />
         <br />
         <button type="button" onClick={this.setActivityKey}>
@@ -121,7 +123,7 @@ class Test extends React.Component {
         <br />
         <br />
         <Collapse
-          headerCollapsableOnly={headerCollapsableOnly}
+          collapsable={collapsable}
           accordion={accordion}
           onChange={this.onChange}
           activeKey={activeKey}

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -77,23 +77,18 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
     if (!child) return null;
 
     const { activeKey } = this.state;
-    const {
-      prefixCls,
-      openMotion,
-      accordion,
-      destroyInactivePanel: rootDestroyInactivePanel,
-      expandIcon,
-      headerCollapsableOnly,
-    } = this.props;
+    const { prefixCls, openMotion, accordion, destroyInactivePanel: rootDestroyInactivePanel, expandIcon, collapsable } = this.props;
     // If there is no key provide, use the panel order as default key
     const key = child.key || String(index);
-    const { header, headerClass, disabled, destroyInactivePanel } = child.props;
+    const { header, headerClass, destroyInactivePanel, collapsable: childCollapsable } = child.props;
     let isActive = false;
     if (accordion) {
       isActive = activeKey[0] === key;
     } else {
       isActive = activeKey.indexOf(key) > -1;
     }
+
+    const mergeCollapsable = childCollapsable === undefined ? collapsable : childCollapsable;
 
     const props = {
       key,
@@ -106,9 +101,9 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       openMotion,
       accordion,
       children: child.props.children,
-      onItemClick: disabled ? null : this.onClickItem,
+      onItemClick: mergeCollapsable === false ? null : this.onClickItem,
       expandIcon,
-      headerCollapsableOnly,
+      collapsable: mergeCollapsable,
     };
 
     // https://github.com/ant-design/ant-design/issues/20479

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -79,7 +79,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
     const { prefixCls, openMotion, accordion, destroyInactivePanel: rootDestroyInactivePanel, expandIcon, collapsible } = this.props;
     // If there is no key provide, use the panel order as default key
     const key = child.key || String(index);
-    const { header, headerClass, destroyInactivePanel, collapsable: childCollapsible } = child.props;
+    const { header, headerClass, destroyInactivePanel, collapsible: childCollapsible } = child.props;
     let isActive = false;
     if (accordion) {
       isActive = activeKey[0] === key;
@@ -87,7 +87,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       isActive = activeKey.indexOf(key) > -1;
     }
 
-    const mergeCollapsible = childCollapsible === undefined ? collapsible : childCollapsible;
+    const mergeCollapsible = childCollapsible ?? collapsible;
 
     const props = {
       key,

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -24,7 +24,6 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
     onChange() {},
     accordion: false,
     destroyInactivePanel: false,
-    headerCollapsableOnly: false,
   };
 
   static Panel = CollapsePanel;
@@ -77,10 +76,10 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
     if (!child) return null;
 
     const { activeKey } = this.state;
-    const { prefixCls, openMotion, accordion, destroyInactivePanel: rootDestroyInactivePanel, expandIcon, collapsable } = this.props;
+    const { prefixCls, openMotion, accordion, destroyInactivePanel: rootDestroyInactivePanel, expandIcon, collapsible } = this.props;
     // If there is no key provide, use the panel order as default key
     const key = child.key || String(index);
-    const { header, headerClass, destroyInactivePanel, collapsable: childCollapsable } = child.props;
+    const { header, headerClass, destroyInactivePanel, collapsable: childCollapsible } = child.props;
     let isActive = false;
     if (accordion) {
       isActive = activeKey[0] === key;
@@ -88,7 +87,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       isActive = activeKey.indexOf(key) > -1;
     }
 
-    const mergeCollapsable = childCollapsable === undefined ? collapsable : childCollapsable;
+    const mergeCollapsible = childCollapsible === undefined ? collapsible : childCollapsible;
 
     const props = {
       key,
@@ -101,9 +100,9 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       openMotion,
       accordion,
       children: child.props.children,
-      onItemClick: mergeCollapsable === false ? null : this.onClickItem,
+      onItemClick: mergeCollapsible === false ? null : this.onClickItem,
       expandIcon,
-      collapsable: mergeCollapsable,
+      collapsible: mergeCollapsible,
     };
 
     // https://github.com/ant-design/ant-design/issues/20479

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -45,17 +45,19 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       isActive,
       showArrow,
       destroyInactivePanel,
-      disabled,
       accordion,
       forceRender,
       openMotion,
       expandIcon,
       extra,
-      headerCollapsableOnly,
+      collapsable,
     } = this.props;
+
+    const disabled = collapsable === false;
+
     const headerCls = classNames(`${prefixCls}-header`, {
       [headerClass]: headerClass,
-      [`${prefixCls}-header-collapsable-only`]: headerCollapsableOnly,
+      [`${prefixCls}-header-collapsable-only`]: collapsable === 'header',
     });
     const itemCls = classNames(
       {
@@ -75,14 +77,14 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       <div className={itemCls} style={style} id={id}>
         <div
           className={headerCls}
-          onClick={() => !headerCollapsableOnly && this.handleItemClick()}
+          onClick={() => collapsable !== 'header' && this.handleItemClick()}
           role={accordion ? 'tab' : 'button'}
           tabIndex={disabled ? -1 : 0}
           aria-expanded={isActive}
           onKeyPress={this.handleKeyPress}
         >
           {showArrow && icon}
-          {headerCollapsableOnly ? (
+          {collapsable === 'header' ? (
             <span onClick={this.handleItemClick} className={`${prefixCls}-header-text`}>
               {header}
             </span>

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -50,14 +50,14 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       openMotion,
       expandIcon,
       extra,
-      collapsable,
+      collapsible,
     } = this.props;
 
-    const disabled = collapsable === false;
+    const disabled = collapsible === false;
 
     const headerCls = classNames(`${prefixCls}-header`, {
       [headerClass]: headerClass,
-      [`${prefixCls}-header-collapsable-only`]: collapsable === 'header',
+      [`${prefixCls}-header-collapsible-only`]: collapsible === 'header',
     });
     const itemCls = classNames(
       {
@@ -77,14 +77,14 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       <div className={itemCls} style={style} id={id}>
         <div
           className={headerCls}
-          onClick={() => collapsable !== 'header' && this.handleItemClick()}
+          onClick={() => collapsible !== 'header' && this.handleItemClick()}
           role={accordion ? 'tab' : 'button'}
           tabIndex={disabled ? -1 : 0}
           aria-expanded={isActive}
           onKeyPress={this.handleKeyPress}
         >
           {showArrow && icon}
-          {collapsable === 'header' ? (
+          {collapsible === 'header' ? (
             <span onClick={this.handleItemClick} className={`${prefixCls}-header-text`}>
               {header}
             </span>

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { CSSMotionProps } from 'rc-motion';
 
+type CollapsableType = boolean | 'header';
+
 export interface CollapseProps {
   prefixCls?: string;
   activeKey?: React.Key | React.Key[];
@@ -12,7 +14,7 @@ export interface CollapseProps {
   style?: object;
   destroyInactivePanel?: boolean;
   expandIcon?: (props: object) => React.ReactNode;
-  headerCollapsableOnly?: boolean;
+  collapsable?: CollapsableType;
 }
 
 export interface CollapsePanelProps {
@@ -25,7 +27,6 @@ export interface CollapsePanelProps {
   style?: object;
   isActive?: boolean;
   openMotion?: CSSMotionProps;
-  disabled?: boolean;
   destroyInactivePanel?: boolean;
   accordion?: boolean;
   forceRender?: boolean;
@@ -34,5 +35,5 @@ export interface CollapsePanelProps {
   expandIcon?: (props: object) => React.ReactNode;
   panelKey?: string | number;
   role?: string;
-  headerCollapsableOnly?: boolean;
+  collapsable?: CollapsableType;
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSMotionProps } from 'rc-motion';
 
-type CollapsableType = boolean | 'header';
+type CollapsibleType = boolean | 'header';
 
 export interface CollapseProps {
   prefixCls?: string;
@@ -14,7 +14,7 @@ export interface CollapseProps {
   style?: object;
   destroyInactivePanel?: boolean;
   expandIcon?: (props: object) => React.ReactNode;
-  collapsable?: CollapsableType;
+  collapsible?: CollapsibleType;
 }
 
 export interface CollapsePanelProps {
@@ -35,5 +35,5 @@ export interface CollapsePanelProps {
   expandIcon?: (props: object) => React.ReactNode;
   panelKey?: string | number;
   role?: string;
-  collapsable?: CollapsableType;
+  collapsible?: CollapsibleType;
 }

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -127,7 +127,7 @@ describe('collapse', () => {
 
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
-        <Panel header="collapse 1" key="1" collapsable={false}>
+        <Panel header="collapse 1" key="1" collapsible={false}>
           first
         </Panel>
         <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
@@ -197,7 +197,7 @@ describe('collapse', () => {
     const expandIcon = () => <span>test{'>'}</span>;
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
-        <Panel header="collapse 1" key={1} collapsable={false}>
+        <Panel header="collapse 1" key={1} collapsible={false}>
           first
         </Panel>
         <Panel header="collapse 2" key={2} extra={<span>ExtraSpan</span>}>
@@ -320,7 +320,7 @@ describe('collapse', () => {
     it('when forceRender is not supplied it should lazy render the panel content', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" collapsable={false}>
+          <Panel header="collapse 1" key="1" collapsible={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -334,7 +334,7 @@ describe('collapse', () => {
     it('when forceRender is FALSE it should lazy render the panel content', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" forceRender={false} collapsable={false}>
+          <Panel header="collapse 1" key="1" forceRender={false} collapsible={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -348,7 +348,7 @@ describe('collapse', () => {
     it('when forceRender is TRUE then it should render all the panel content to the DOM', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" forceRender collapsable={false}>
+          <Panel header="collapse 1" key="1" forceRender collapsible={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -377,7 +377,7 @@ describe('collapse', () => {
           <Panel header="collapse 2" key="2">
             second
           </Panel>
-          <Panel header="collapse 3" key="3" collapsable={false}>
+          <Panel header="collapse 3" key="3" collapsible={false}>
             second
           </Panel>
         </Collapse>,
@@ -429,7 +429,7 @@ describe('collapse', () => {
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
         <Fragment>
-          <Panel header="collapse 1" key="1" collapsable={false}>
+          <Panel header="collapse 1" key="1" collapsible={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
@@ -475,7 +475,7 @@ describe('collapse', () => {
     expect(collapse.find('.custom-child').getDOMNode().innerHTML).toBe('custom-child');
   });
 
-  describe('collapsable', () => {
+  describe('collapsible', () => {
     it('default', () => {
       const collapse = mount(
         <Collapse>
@@ -490,7 +490,7 @@ describe('collapse', () => {
     });
     it('should work when value is header', () => {
       const collapse = mount(
-        <Collapse collapsable="header">
+        <Collapse collapsible="header">
           <Panel header="collapse 1" key="1">
             first
           </Panel>
@@ -505,7 +505,7 @@ describe('collapse', () => {
 
     it('should disabled when value is false', () => {
       const collapse = mount(
-        <Collapse collapsable={false}>
+        <Collapse collapsible={false}>
           <Panel header="collapse 1" key="1">
             first
           </Panel>
@@ -521,8 +521,8 @@ describe('collapse', () => {
 
     it('the value of panel should be read first', () => {
       const collapse = mount(
-        <Collapse collapsable="header">
-          <Panel collapsable={false} header="collapse 1" key="1">
+        <Collapse collapsible="header">
+          <Panel collapsible={false} header="collapse 1" key="1">
             first
           </Panel>
         </Collapse>,

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -127,7 +127,7 @@ describe('collapse', () => {
 
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
-        <Panel header="collapse 1" key="1" disabled>
+        <Panel header="collapse 1" key="1" collapsable={false}>
           first
         </Panel>
         <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
@@ -197,7 +197,7 @@ describe('collapse', () => {
     const expandIcon = () => <span>test{'>'}</span>;
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
-        <Panel header="collapse 1" key={1} disabled>
+        <Panel header="collapse 1" key={1} collapsable={false}>
           first
         </Panel>
         <Panel header="collapse 2" key={2} extra={<span>ExtraSpan</span>}>
@@ -320,7 +320,7 @@ describe('collapse', () => {
     it('when forceRender is not supplied it should lazy render the panel content', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" disabled>
+          <Panel header="collapse 1" key="1" collapsable={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -334,7 +334,7 @@ describe('collapse', () => {
     it('when forceRender is FALSE it should lazy render the panel content', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" forceRender={false} disabled>
+          <Panel header="collapse 1" key="1" forceRender={false} collapsable={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -348,7 +348,7 @@ describe('collapse', () => {
     it('when forceRender is TRUE then it should render all the panel content to the DOM', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" forceRender disabled>
+          <Panel header="collapse 1" key="1" forceRender collapsable={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -377,7 +377,7 @@ describe('collapse', () => {
           <Panel header="collapse 2" key="2">
             second
           </Panel>
-          <Panel header="collapse 3" key="3" disabled>
+          <Panel header="collapse 3" key="3" collapsable={false}>
             second
           </Panel>
         </Collapse>,
@@ -429,7 +429,7 @@ describe('collapse', () => {
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
         <Fragment>
-          <Panel header="collapse 1" key="1" disabled>
+          <Panel header="collapse 1" key="1" collapsable={false}>
             first
           </Panel>
           <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
@@ -475,7 +475,7 @@ describe('collapse', () => {
     expect(collapse.find('.custom-child').getDOMNode().innerHTML).toBe('custom-child');
   });
 
-  describe('headerCollapsableOnly', () => {
+  describe('collapsable', () => {
     it('default', () => {
       const collapse = mount(
         <Collapse>
@@ -485,10 +485,12 @@ describe('collapse', () => {
         </Collapse>,
       );
       expect(collapse.find('.rc-collapse-header-text').exists()).toBeFalsy();
+      collapse.find('.rc-collapse-header').simulate('click');
+      expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
     });
-    it('should work', () => {
+    it('should work when value is header', () => {
       const collapse = mount(
-        <Collapse headerCollapsableOnly>
+        <Collapse collapsable="header">
           <Panel header="collapse 1" key="1">
             first
           </Panel>
@@ -499,6 +501,38 @@ describe('collapse', () => {
       expect(collapse.find('.rc-collapse-item-active').length).toBe(0);
       collapse.find('.rc-collapse-header-text').simulate('click');
       expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
+    });
+
+    it('should disabled when value is false', () => {
+      const collapse = mount(
+        <Collapse collapsable={false}>
+          <Panel header="collapse 1" key="1">
+            first
+          </Panel>
+        </Collapse>,
+      );
+      expect(collapse.find('.rc-collapse-header-text').exists()).toBeFalsy();
+
+      expect(collapse.find('.rc-collapse-item-disabled').length).toBe(1);
+
+      collapse.find('.rc-collapse-header').simulate('click');
+      expect(collapse.find('.rc-collapse-item-active').length).toBe(0);
+    });
+
+    it('the value of panel should be read first', () => {
+      const collapse = mount(
+        <Collapse collapsable="header">
+          <Panel collapsable={false} header="collapse 1" key="1">
+            first
+          </Panel>
+        </Collapse>,
+      );
+      expect(collapse.find('.rc-collapse-header-text').exists()).toBeFalsy();
+
+      expect(collapse.find('.rc-collapse-item-disabled').length).toBe(1);
+
+      collapse.find('.rc-collapse-header').simulate('click');
+      expect(collapse.find('.rc-collapse-item-active').length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## API 改动

- Collapse 与 Panel 添加 `collapsible` 属性，取值为 `boolean` 或 `'header'`，默认为 `undefined` 即为 `true`
	- `true` 时，Panel 的 header 所有区域均可点击触发展开行为
    - `false` 时，相当于给所有的 Panel 子元素设置了 `disabled` 属性，header 区域不可点击，样式与之前的 `disabled` 时相同
	- `header` 时，只有点击 Panel 的 header 中的文字区域时才可触发展开行为，点击箭头 icon等不会触发

> 当 Collapse 与 Panel 同时有 `collapsible` 时，优先读取 Panel 的值。

- 删除 2.1.0 中的 `headerCollapsableOnly` 属性
- 删除 Panel 中的 `disabled` 属性，使用 `collapsible=false` 代替