### PR TITLE
chore: refactor collapsible value

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ ReactDOM.render(collapse, container);
       </tr>
       <tr>
           <td>collapsible</td>
-          <td>Boolean | 'header'</td>
-          <th>true</th>
+          <td>'header' | 'disabled'</td>
+          <th>-</th>
           <td>specify whether the panel of children is collapsible or the area of collapsible.</td>
       </tr>
     </tbody>
@@ -183,12 +183,6 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
         <td>set the animation of open behavior, [more](https://github.com/react-component/motion). Different with v2, closed pane use a `rc-collapse-content-hidden` class to set `display: none` for hidden.</td>
       </tr>
       <tr>
-        <td>disabled</td>
-        <td>boolean</td>
-        <th>false</th>
-        <td>whether the panel is collapsible</td>
-      </tr>
-      <tr>
         <td>forceRender</td>
         <td>boolean</td>
         <th>false</th>
@@ -202,14 +196,14 @@ If `accordion` is true, only one panel can be open.  Opening another panel will 
       </tr>
       <tr>
           <td>collapsible</td>
-          <td>Boolean | 'header'</td>
-          <th>true</th>
+          <td>'header' | 'disabled'</td>
+          <th>-</th>
           <td>specify whether the panel be collapsible or the area of collapsible.</td>
       </tr>
     </tbody>
 </table>
 
-> `disabled` is removed since 3.0.0, please use `collapsible=false` replace it.
+> `disabled` is removed since 3.0.0, please use `collapsible=disabled` replace it.
 
 #### key
 

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -18,7 +18,7 @@ class Test extends React.Component {
     time: random(),
     accordion: false,
     activeKey: ['4'],
-    collapsible: true,
+    collapsible: undefined,
   };
 
   onChange = (activeKey: string) => {
@@ -36,7 +36,7 @@ class Test extends React.Component {
         <Panel
           header={`This is panel header ${key}`}
           key={key}
-          collapsible={i === 0 ? false : undefined}
+          collapsible={i === 0 ? 'disabled' : undefined}
         >
           <p>{text.repeat(this.state.time)}</p>
         </Panel>,
@@ -94,7 +94,7 @@ class Test extends React.Component {
   };
 
   handleCollapsibleChange = (e: any) => {
-    const values = [true, 'header', false];
+    const values = [undefined, 'header', 'disabled'];
     this.setState({
       collapsible: values[e.target.value],
     });
@@ -114,9 +114,9 @@ class Test extends React.Component {
         <p>
           collapsible:
           <select onChange={this.handleCollapsibleChange}>
-            <option value={0}>true</option>
+            <option value={0}>default</option>
             <option value={1}>header</option>
-            <option value={2}>false</option>
+            <option value={2}>disabled</option>
           </select>
         </p>
         <br />

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import toArray from 'rc-util/lib/Children/toArray';
 import CollapsePanel from './Panel';
-import { CollapseProps } from './interface';
+import { CollapseProps, CollapsibleType } from './interface';
 
 function getActiveKeysArray(activeKey: React.Key | React.Key[]) {
   let currentActiveKey = activeKey;
@@ -87,7 +87,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       isActive = activeKey.indexOf(key) > -1;
     }
 
-    const mergeCollapsible = childCollapsible ?? collapsible;
+    const mergeCollapsible: CollapsibleType  = childCollapsible ?? collapsible;
 
     const props = {
       key,
@@ -100,7 +100,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       openMotion,
       accordion,
       children: child.props.children,
-      onItemClick: mergeCollapsible === false ? null : this.onClickItem,
+      onItemClick: mergeCollapsible === 'disabled' ? null : this.onClickItem,
       expandIcon,
       collapsible: mergeCollapsible,
     };

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -53,7 +53,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       collapsible,
     } = this.props;
 
-    const disabled = collapsible === false;
+    const disabled = collapsible === 'disabled';
 
     const headerCls = classNames(`${prefixCls}-header`, {
       [headerClass]: headerClass,

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSMotionProps } from 'rc-motion';
 
-type CollapsibleType = boolean | 'header';
+export type CollapsibleType = 'header' | 'disabled';
 
 export interface CollapseProps {
   prefixCls?: string;

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -127,7 +127,7 @@ describe('collapse', () => {
 
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
-        <Panel header="collapse 1" key="1" collapsible={false}>
+        <Panel header="collapse 1" key="1" collapsible="disabled">
           first
         </Panel>
         <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
@@ -197,7 +197,7 @@ describe('collapse', () => {
     const expandIcon = () => <span>test{'>'}</span>;
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
-        <Panel header="collapse 1" key={1} collapsible={false}>
+        <Panel header="collapse 1" key={1} collapsible="disabled">
           first
         </Panel>
         <Panel header="collapse 2" key={2} extra={<span>ExtraSpan</span>}>
@@ -320,7 +320,7 @@ describe('collapse', () => {
     it('when forceRender is not supplied it should lazy render the panel content', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" collapsible={false}>
+          <Panel header="collapse 1" key="1" collapsible="disabled">
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -334,7 +334,7 @@ describe('collapse', () => {
     it('when forceRender is FALSE it should lazy render the panel content', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" forceRender={false} collapsible={false}>
+          <Panel header="collapse 1" key="1" forceRender={false} collapsible="disabled">
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -348,7 +348,7 @@ describe('collapse', () => {
     it('when forceRender is TRUE then it should render all the panel content to the DOM', () => {
       renderCollapse(
         <Collapse>
-          <Panel header="collapse 1" key="1" forceRender collapsible={false}>
+          <Panel header="collapse 1" key="1" forceRender collapsible="disabled">
             first
           </Panel>
           <Panel header="collapse 2" key="2">
@@ -378,7 +378,7 @@ describe('collapse', () => {
           <Panel header="collapse 2" key="2">
             second
           </Panel>
-          <Panel header="collapse 3" key="3" collapsible={false}>
+          <Panel header="collapse 3" key="3" collapsible="disabled">
             second
           </Panel>
         </Collapse>,
@@ -430,7 +430,7 @@ describe('collapse', () => {
     const element = (
       <Collapse onChange={onChange} expandIcon={expandIcon}>
         <Fragment>
-          <Panel header="collapse 1" key="1" collapsible={false}>
+          <Panel header="collapse 1" key="1" collapsible="disabled">
             first
           </Panel>
           <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
@@ -504,9 +504,9 @@ describe('collapse', () => {
       expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
     });
 
-    it('should disabled when value is false', () => {
+    it('should disabled when value is disabled', () => {
       const collapse = mount(
-        <Collapse collapsible={false}>
+        <Collapse collapsible="disabled">
           <Panel header="collapse 1" key="1">
             first
           </Panel>
@@ -523,7 +523,7 @@ describe('collapse', () => {
     it('the value of panel should be read first', () => {
       const collapse = mount(
         <Collapse collapsible="header">
-          <Panel collapsible={false} header="collapse 1" key="1">
+          <Panel collapsible="disabled" header="collapse 1" key="1">
             first
           </Panel>
         </Collapse>,


### PR DESCRIPTION
### 改动点

- 3.0.0 中 `collapsible` 属性取值为 `boolean`、`header`，因为之前 @afc163 说的，`false` 和 `disabled` 样式和语义上有所区别，所以这次，把此属性的取值修改为 `header`、`disabled`，去掉了之前的 `boolean`。

这次的改动相对于 3.0.0 来说改动还是比较大，所以大家看看有没有遗漏的地方或者不合适的，还需要确认的是这次的改动是发一下 major 还是 minor 版本。

@zombieJ 