### PR TITLE
feat: 添加headerProps基于panel props自定义panel header

### DIFF
--- a/examples/custom-collapse-header.tsx
+++ b/examples/custom-collapse-header.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import Collapse, { Panel } from '../src';
+import motion from './_util/motionUtil';
+import '../assets/index.less';
+
+const text = `
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+`;
+
+function random() {
+  return parseInt((Math.random() * 10).toString(), 10) + 1;
+}
+
+class Test extends React.Component {
+  state = {
+    time: random(),
+    accordion: false,
+    activeKey: ['4'],
+    collapsible: undefined,
+  };
+
+  onChange = (activeKey: string) => {
+    this.setState({
+      activeKey,
+    });
+  };
+
+  getItems() {
+    const items = [];
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0, len = 3; i < len; i++) {
+      const key = i + 1;
+      items.push(
+        <Panel
+          header={`This is panel header ${key}`}
+          key={key}
+          collapsible={i === 0 ? 'disabled' : undefined}
+        >
+          <p>{text.repeat(this.state.time)}</p>
+        </Panel>,
+      );
+    }
+    items.push(
+      <Panel header="This is panel header 4" key="4">
+        <Collapse defaultActiveKey="1">
+          <Panel header="This is panel nest panel" key="41" id="header-test">
+            <p>{text}</p>
+          </Panel>
+        </Collapse>
+      </Panel>,
+    );
+
+    items.push(
+      <Panel header="This is panel header 5" key="5">
+        <Collapse defaultActiveKey="1">
+          <Panel header="This is panel nest panel" key="51" id="another-test">
+            <form>
+              <label htmlFor="test">Name:&nbsp;</label>
+              <input type="text" id="test" />
+            </form>
+          </Panel>
+        </Collapse>
+      </Panel>,
+    );
+
+    items.push(
+      <Panel header="This is panel header 6" key="6" extra={<span>Extra Node</span>}>
+        <p>Panel with extra</p>
+      </Panel>,
+    );
+
+    return items;
+  }
+
+  setActivityKey = () => {
+    this.setState({
+      activeKey: ['2'],
+    });
+  };
+
+  reRender = () => {
+    this.setState({
+      time: random(),
+    });
+  };
+
+  toggle = () => {
+    const { accordion } = this.state;
+    this.setState({
+      accordion: !accordion,
+    });
+  };
+
+  handleCollapsibleChange = (e: any) => {
+    const values = [undefined, 'header', 'disabled'];
+    this.setState({
+      collapsible: values[e.target.value],
+    });
+  };
+
+  render() {
+    const { accordion, activeKey, collapsible } = this.state;
+    const btn = accordion ? 'Mode: accordion' : 'Mode: collapse';
+    return (
+      <div style={{ margin: 20, width: 400 }}>
+        <button type="button" onClick={this.reRender}>
+          reRender
+        </button>
+        <button type="button" onClick={this.toggle}>
+          {btn}
+        </button>
+        <p>
+          collapsible:
+          <select onChange={this.handleCollapsibleChange}>
+            <option value={0}>default</option>
+            <option value={1}>header</option>
+            <option value={2}>disabled</option>
+          </select>
+        </p>
+        <br />
+        <br />
+        <button type="button" onClick={this.setActivityKey}>
+          active header 2
+        </button>
+        <br />
+        <br />
+        <Collapse
+          collapsible={collapsible}
+          accordion={accordion}
+          onChange={this.onChange}
+          activeKey={activeKey}
+          openMotion={motion}
+          // 获取panel props来自定义渲染header
+          // 比panel header上的其他配置项优先级高
+          headerRender={({ header, isActive, extra }) => {
+            return (
+              <div style={{ display: 'flex' }}>
+                <div>
+                  {header}
+                  <span style={{ marginLeft: 10 }}>{isActive ? '收起' : '展开'}</span>
+                </div>
+                <div style={{ marginLeft: 20 }}>{extra}</div>
+              </div>
+            );
+          }}
+        >
+          {this.getItems()}
+        </Collapse>
+      </div>
+    );
+  }
+}
+
+export default Test;

--- a/examples/custom-collapse-header.tsx
+++ b/examples/custom-collapse-header.tsx
@@ -13,6 +13,18 @@ function random() {
   return parseInt((Math.random() * 10).toString(), 10) + 1;
 }
 
+function customHeaderRender({ header, isActive, extra }) {
+  return (
+    <div style={{ display: 'flex' }}>
+      <div>
+        {header}
+        <span style={{ marginLeft: 10 }}>{isActive ? '收起' : '展开'}</span>
+      </div>
+      <div style={{ marginLeft: 20 }}>{extra}</div>
+    </div>
+  );
+}
+
 class Test extends React.Component {
   state = {
     time: random(),
@@ -134,17 +146,7 @@ class Test extends React.Component {
           openMotion={motion}
           // 获取panel props来自定义渲染header
           // 比panel header上的其他配置项优先级高
-          headerRender={({ header, isActive, extra }) => {
-            return (
-              <div style={{ display: 'flex' }}>
-                <div>
-                  {header}
-                  <span style={{ marginLeft: 10 }}>{isActive ? '收起' : '展开'}</span>
-                </div>
-                <div style={{ marginLeft: 20 }}>{extra}</div>
-              </div>
-            );
-          }}
+          headerRender={customHeaderRender}
         >
           {this.getItems()}
         </Collapse>

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import shallowEqual from 'shallowequal';
 import toArray from 'rc-util/lib/Children/toArray';
 import CollapsePanel from './Panel';
-import { CollapseProps, CollapsibleType } from './interface';
+import type { CollapseProps, CollapsibleType } from './interface';
 
 function getActiveKeysArray(activeKey: React.Key | React.Key[]) {
   let currentActiveKey = activeKey;
@@ -78,10 +78,23 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
     if (!child) return null;
 
     const { activeKey } = this.state;
-    const { prefixCls, openMotion, accordion, destroyInactivePanel: rootDestroyInactivePanel, expandIcon, collapsible } = this.props;
+    const {
+      prefixCls,
+      openMotion,
+      accordion,
+      destroyInactivePanel: rootDestroyInactivePanel,
+      expandIcon,
+      headerRender,
+      collapsible,
+    } = this.props;
     // If there is no key provide, use the panel order as default key
     const key = child.key || String(index);
-    const { header, headerClass, destroyInactivePanel, collapsible: childCollapsible } = child.props;
+    const {
+      header,
+      headerClass,
+      destroyInactivePanel,
+      collapsible: childCollapsible,
+    } = child.props;
     let isActive = false;
     if (accordion) {
       isActive = activeKey[0] === key;
@@ -89,7 +102,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       isActive = activeKey.indexOf(key) > -1;
     }
 
-    const mergeCollapsible: CollapsibleType  = childCollapsible ?? collapsible;
+    const mergeCollapsible: CollapsibleType = childCollapsible ?? collapsible;
 
     const props = {
       key,
@@ -104,6 +117,7 @@ class Collapse extends React.Component<CollapseProps, CollapseState> {
       children: child.props.children,
       onItemClick: mergeCollapsible === 'disabled' ? null : this.onClickItem,
       expandIcon,
+      headerRender,
       collapsible: mergeCollapsible,
     };
 

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -49,6 +49,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       forceRender,
       openMotion,
       expandIcon,
+      headerRender,
       extra,
       collapsible,
     } = this.props;
@@ -98,15 +99,21 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
     return (
       <div className={itemCls} style={style} id={id}>
         <div {...headerProps}>
-          {showArrow && icon}
-          {collapsibleHeader ? (
-            <span onClick={this.handleItemClick} className={`${prefixCls}-header-text`}>
-              {header}
-            </span>
+          {headerRender && typeof headerRender === 'function' ? (
+            headerRender(this.props)
           ) : (
-            header
+            <>
+              {showArrow && icon}
+              {collapsibleHeader ? (
+                <span onClick={this.handleItemClick} className={`${prefixCls}-header-text`}>
+                  {header}
+                </span>
+              ) : (
+                header
+              )}
+              {ifExtraExist && <div className={`${prefixCls}-extra`}>{extra}</div>}
+            </>
           )}
-          {ifExtraExist && <div className={`${prefixCls}-extra`}>{extra}</div>}
         </div>
         <CSSMotion
           visible={isActive}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { CSSMotionProps } from 'rc-motion';
+import type * as React from 'react';
+import type { CSSMotionProps } from 'rc-motion';
 
 export type CollapsibleType = 'header' | 'disabled';
 
@@ -15,6 +15,7 @@ export interface CollapseProps {
   destroyInactivePanel?: boolean;
   expandIcon?: (props: object) => React.ReactNode;
   collapsible?: CollapsibleType;
+  headerRender?: (props: object) => React.ReactNode;
 }
 
 export interface CollapsePanelProps {
@@ -33,6 +34,7 @@ export interface CollapsePanelProps {
   extra?: string | React.ReactNode;
   onItemClick?: (panelKey: string | number) => void;
   expandIcon?: (props: object) => React.ReactNode;
+  headerRender?: (props: object) => React.ReactNode;
   panelKey?: string | number;
   role?: string;
   collapsible?: CollapsibleType;

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -559,4 +559,50 @@ describe('collapse', () => {
       expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
     });
   });
+
+  describe('customHeader', () => {
+    const customHeaderRender = ({ header, isActive, extra }) => {
+      return (
+        <div style={{ display: 'flex' }}>
+          <div>
+            {header}
+            <span style={{ marginLeft: 10 }}>{isActive ? '收起' : '展开'}</span>
+          </div>
+          <div style={{ marginLeft: 20 }}>{extra}</div>
+        </div>
+      );
+    };
+
+    let collapse: ReactWrapper;
+    beforeEach(() => {
+      collapse = mount(
+        <Collapse onChange={onChange} headerRender={customHeaderRender}>
+          <Panel header="collapse 1" key="1" collapsible="disabled">
+            first
+          </Panel>
+          <Panel header="collapse 2" key="2" extra={<span>ExtraSpan</span>}>
+            second
+          </Panel>
+          <Panel header="collapse 3" key="3" className="important">
+            third
+          </Panel>
+        </Collapse>,
+      );
+    });
+
+    it('should toggle show on panel', () => {
+      let header = collapse.find('.rc-collapse-header').at(1);
+      header.simulate('click');
+      jest.runAllTimers();
+      collapse.update();
+      expect(collapse.find('.rc-collapse-content-active').length).toBe(1);
+      expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
+      header = collapse.find('.rc-collapse-header').at(1);
+      header.simulate('click');
+      jest.runAllTimers();
+      collapse.update();
+      expect(collapse.find('.rc-collapse-content-active').exists()).toBeFalsy();
+      expect(collapse.find('.rc-collapse-item-active').exists()).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
我现在有个需求是需要让expandIcon接跟着header的右侧，而不是在panel的最右边。所以添加了一个headerRender的props，类似于expandIcon，它可以接收整个panel的props并返回一个ReactNode以此来最大化用户的自由度。

如果加这个属性OK的话我之后给antd那边提个pr把属性给补充上