### PR TITLE
Adds "aria-disabled" attribute

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -75,6 +75,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
     const headerProps: React.HTMLAttributes<HTMLDivElement> = {
       className: headerCls,
       'aria-expanded': isActive,
+      'aria-disabled': disabled,
       onKeyPress: this.handleKeyPress,
     };
 


### PR DESCRIPTION
For accessibility, collapse element should have an aria-disabled attribute

Cases: aria-disabled=

- `true` collapse is disabled
- `false` collapse is not disabled

There are elements that use color as the only visual means to convey state, selection, or other information.

Example:
The "Panel header" accordion is styled to look disabled but it is not conveyed programmatically.

Users who cannot distinguish colors will not have access to the information conveyed by the use of color and may find the page unusable.

learn more - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled

Reference issue - https://github.com/react-component/collapse/issues/229

Ref: MILL-311