### PR TITLE
refactor: Wrap all part with element holder

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -19,7 +19,7 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
     return !shallowEqual(this.props, nextProps);
   }
 
-  handleItemClick = () => {
+  onItemClick = () => {
     const { onItemClick, panelKey } = this.props;
 
     if (typeof onItemClick === 'function') {
@@ -29,8 +29,42 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
 
   handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.keyCode === 13 || e.which === 13) {
-      this.handleItemClick();
+      this.onItemClick();
     }
+  };
+
+  renderIcon = () => {
+    const { showArrow, expandIcon, prefixCls, collapsible } = this.props;
+    if (!showArrow) {
+      return null;
+    }
+
+    const iconNode =
+      typeof expandIcon === 'function' ? expandIcon(this.props) : <i className="arrow" />;
+
+    return (
+      iconNode && (
+        <div
+          className={`${prefixCls}-expand-icon`}
+          onClick={collapsible === 'header' ? this.onItemClick : null}
+        >
+          {iconNode}
+        </div>
+      )
+    );
+  };
+
+  renderTitle = () => {
+    const { header, prefixCls, collapsible } = this.props;
+
+    return (
+      <span
+        className={`${prefixCls}-header-text`}
+        onClick={collapsible === 'header' ? this.onItemClick : null}
+      >
+        {header}
+      </span>
+    );
   };
 
   render() {
@@ -39,16 +73,13 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       id,
       style,
       prefixCls,
-      header,
       headerClass,
       children,
       isActive,
-      showArrow,
       destroyInactivePanel,
       accordion,
       forceRender,
       openMotion,
-      expandIcon,
       extra,
       collapsible,
     } = this.props;
@@ -56,10 +87,6 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
     const disabled = collapsible === 'disabled';
     const collapsibleHeader = collapsible === 'header';
 
-    const headerCls = classNames(`${prefixCls}-header`, {
-      [headerClass]: headerClass,
-      [`${prefixCls}-header-collapsible-only`]: collapsibleHeader,
-    });
     const itemCls = classNames(
       {
         [`${prefixCls}-item`]: true,
@@ -69,7 +96,10 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       className,
     );
 
-    let icon: any = <i className="arrow" />;
+    const headerCls = classNames(`${prefixCls}-header`, {
+      [headerClass]: headerClass,
+      [`${prefixCls}-header-collapsible-only`]: collapsibleHeader,
+    });
 
     /** header 节点属性 */
     const headerProps: React.HTMLAttributes<HTMLDivElement> = {
@@ -78,17 +108,8 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
       onKeyPress: this.handleKeyPress,
     };
 
-    if (showArrow && typeof expandIcon === 'function') {
-      icon = expandIcon(this.props);
-    }
-    if (collapsibleHeader) {
-      icon = (
-        <span style={{ cursor: 'pointer' }} onClick={() => this.handleItemClick()}>
-          {icon}
-        </span>
-      );
-    } else {
-      headerProps.onClick = this.handleItemClick;
+    if (!collapsibleHeader) {
+      headerProps.onClick = this.onItemClick;
       headerProps.role = accordion ? 'tab' : 'button';
       headerProps.tabIndex = disabled ? -1 : 0;
     }
@@ -98,14 +119,8 @@ class CollapsePanel extends React.Component<CollapsePanelProps, any> {
     return (
       <div className={itemCls} style={style} id={id}>
         <div {...headerProps}>
-          {showArrow && icon}
-          {collapsibleHeader ? (
-            <span onClick={this.handleItemClick} className={`${prefixCls}-header-text`}>
-              {header}
-            </span>
-          ) : (
-            header
-          )}
+          {this.renderIcon()}
+          {this.renderTitle()}
           {ifExtraExist && <div className={`${prefixCls}-extra`}>{extra}</div>}
         </div>
         <CSSMotion

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -139,8 +139,7 @@ describe('collapse', () => {
           activeKey: ['2'],
         };
 
-        constructor(props: any) {
-          super(props);
+        componentDidMount(): void {
           this.setState({
             activeKey: ['2'],
           });
@@ -471,6 +470,7 @@ describe('collapse', () => {
         </Panel>
       </Collapse>,
     );
+    console.log('>>>', wrapper.find('.rc-collapse-header').html());
     expect(wrapper.find('.rc-collapse-header').at(0).getDOMNode().childNodes.length).toBe(1);
   });
 
@@ -495,7 +495,7 @@ describe('collapse', () => {
           </Panel>
         </Collapse>,
       );
-      expect(collapse.find('.rc-collapse-header-text').exists()).toBeFalsy();
+      expect(collapse.find('.rc-collapse-header-text').exists()).toBeTruthy();
       collapse.find('.rc-collapse-header').simulate('click');
       expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
     });
@@ -522,7 +522,7 @@ describe('collapse', () => {
           </Panel>
         </Collapse>,
       );
-      expect(collapse.find('.rc-collapse-header-text').exists()).toBeFalsy();
+      expect(collapse.find('.rc-collapse-header-text').exists()).toBeTruthy();
 
       expect(collapse.find('.rc-collapse-item-disabled').length).toBe(1);
 
@@ -538,7 +538,7 @@ describe('collapse', () => {
           </Panel>
         </Collapse>,
       );
-      expect(collapse.find('.rc-collapse-header-text').exists()).toBeFalsy();
+      expect(collapse.find('.rc-collapse-header-text').exists()).toBeTruthy();
 
       expect(collapse.find('.rc-collapse-item-disabled').length).toBe(1);
 

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -470,7 +470,6 @@ describe('collapse', () => {
         </Panel>
       </Collapse>,
     );
-    console.log('>>>', wrapper.find('.rc-collapse-header').html());
     expect(wrapper.find('.rc-collapse-header').at(0).getDOMNode().childNodes.length).toBe(1);
   });
 
@@ -558,5 +557,17 @@ describe('collapse', () => {
       collapse.find('.rc-collapse-header .arrow').simulate('click');
       expect(collapse.find('.rc-collapse-item-active').length).toBe(1);
     });
+  });
+
+  it('!showArrow', () => {
+    const wrapper = mount(
+      <Collapse>
+        <Panel header="collapse 1" key="1" showArrow={false}>
+          first
+        </Panel>
+      </Collapse>,
+    );
+
+    expect(wrapper.exists('.rc-collapse-expand-icon')).toBeFalsy();
   });
 });


### PR DESCRIPTION
header 不是每次都有 holder 对于 flex 布局来说比较麻烦，现在全部包一下样式里就会简单很多。