### PR TITLE
fix: Correctly applying headerClass to the collapse-header

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -64,9 +64,8 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
     className,
   );
 
-  const headerClassName = classNames({
+  const headerClassName = classNames(headerClass, {
     [`${prefixCls}-header`]: true,
-    headerClass,
     [`${prefixCls}-header-collapsible-only`]: collapsibleHeader,
     [`${prefixCls}-icon-collapsible-only`]: collapsibleIcon,
   });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -188,6 +188,24 @@ describe('collapse', () => {
     runNormalTest(element);
   });
 
+  describe('prop: headerClass', () => {
+    it('applies the passed headerClass to the header', () => {
+
+      const element = (
+        <Collapse onChange={onChange} >
+          <Panel header="collapse 1" key="1" headerClass='custom-class'>
+            first
+          </Panel>
+        </Collapse>
+      );
+
+      const {container} = render(element)
+      const header = container.querySelector('.rc-collapse-header');
+
+      expect(header.classList.contains('custom-class')).toBeTruthy();
+    })
+  })
+
   it('shoule support extra whit number 0', () => {
     const { container } = render(
       <Collapse onChange={onChange} activeKey={0}>


### PR DESCRIPTION
Fixes the headerClass not being applied correctly when passed down. 

fix https://github.com/react-component/collapse/issues/311