### PR TITLE
feat: can use a wrapper on panel when using items props of collapse

### DIFF
--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -24,6 +24,7 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     const {
       children,
       label,
+      wrapper,
       key: rawKey,
       collapsible: rawCollapsible,
       onItemClick: rawOnItemClick,
@@ -50,7 +51,7 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
       isActive = activeKey.indexOf(key) > -1;
     }
 
-    return (
+    const collapsePanel = (
       <CollapsePanel
         {...restProps}
         prefixCls={prefixCls}
@@ -68,6 +69,12 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
         {children}
       </CollapsePanel>
     );
+
+    if (wrapper) {
+      return wrapper(collapsePanel);
+    }
+
+    return collapsePanel;
   });
 };
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,5 +1,6 @@
 import type { CSSMotionProps } from 'rc-motion';
 import type * as React from 'react';
+import type { ReactNode } from 'react';
 
 export type CollapsibleType = 'header' | 'icon' | 'disabled';
 
@@ -16,6 +17,7 @@ export interface ItemType
   > {
   key?: CollapsePanelProps['panelKey'];
   label?: CollapsePanelProps['header'];
+  wrapper?: ReactNode;
   ref?: React.RefObject<HTMLDivElement>;
 }
 


### PR DESCRIPTION
Today its not possible to add some wrapper like Context when using items props with Collapse