### PR TITLE
type: narrow onChange argument to React.Key[]

### DIFF
--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -38,7 +38,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
 
   const [activeKey, setActiveKey] = useMergedState<React.Key | React.Key[], React.Key[]>([], {
     value: rawActiveKey,
-    onChange: (v) => onChange?.(v),
+    onChange: (v) => onChange?.(v as React.Key[]),
     defaultValue: defaultActiveKey,
     postState: getActiveKeysArray,
   });

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -24,7 +24,7 @@ export interface CollapseProps {
   activeKey?: React.Key | React.Key[];
   defaultActiveKey?: React.Key | React.Key[];
   openMotion?: CSSMotionProps;
-  onChange?: (key: React.Key | React.Key[]) => void;
+  onChange?: (key: React.Key[]) => void;
   accordion?: boolean;
   className?: string;
   style?: object;


### PR DESCRIPTION
https://github.com/ant-design/ant-design/pull/50754


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了`Collapse`组件的`onChange`回调，增强了类型安全性，确保回调接收一个键数组。
- **接口变更**
	- 更新了`CollapseProps`接口中的`onChange`属性，使其仅接受键数组，确保一致性和清晰性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->