### PR TITLE
fix(a11y): assign correct role when collapsible prop is 'icon' or 'header'

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -83,11 +83,11 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
     'aria-disabled': disabled,
     onKeyDown: handleKeyDown,
     style: styles.header,
+    role: accordion ? 'tab' : 'button',
   };
 
   if (!collapsibleHeader && !collapsibleIcon) {
     headerProps.onClick = handleItemClick;
-    headerProps.role = accordion ? 'tab' : 'button';
     headerProps.tabIndex = disabled ? -1 : 0;
   }
 


### PR DESCRIPTION
	•当 collapsible 为 'icon' 或 'header' 时，确保为折叠区域正确赋值 role="button" 属性。
	•通过此修复，改进了组件在屏幕阅读器和键盘导航下的表现，确保更好的无障碍支持。

![QQ_1729791265760](https://github.com/user-attachments/assets/c46e6c32-6306-439f-b610-802e5312262a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增强了 `CollapsePanel` 组件的可访问性，添加了适当的 ARIA 角色属性。
- **改进**
	- 根据组件状态和属性条件设置 `tabIndex`，确保头部在非交互状态下的正确行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->