### PR TITLE
feat: useItems support classnames and styles

### DIFF
--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -32,6 +32,8 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     defaultActiveKey,
     onChange,
     items,
+    classNames: customizeClassNames,
+    styles,
   } = props;
 
   const collapseClassName = classNames(prefixCls, className);
@@ -73,6 +75,8 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     destroyInactivePanel,
     onItemClick,
     activeKey,
+    classNames: customizeClassNames,
+    styles,
   });
 
   // ======================== Render ========================

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -21,6 +21,8 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     activeKey,
     openMotion,
     expandIcon,
+    classNames: collapseClassNames,
+    styles,
   } = props;
 
   return items.map((item, index) => {
@@ -56,6 +58,8 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     return (
       <CollapsePanel
         {...restProps}
+        classNames={collapseClassNames}
+        styles={styles}
         prefixCls={prefixCls}
         key={key}
         panelKey={key}

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import type { CollapsePanelProps, CollapseProps, ItemType } from '../interface';
 import CollapsePanel from '../Panel';
 
-type Props = Pick<CollapsePanelProps, 'prefixCls' | 'onItemClick' | 'openMotion' | 'expandIcon'> &
+type Props = Pick<
+  CollapsePanelProps,
+  'prefixCls' | 'onItemClick' | 'openMotion' | 'expandIcon' | 'classNames' | 'styles'
+> &
   Pick<CollapseProps, 'accordion' | 'collapsible' | 'destroyInactivePanel'> & {
     activeKey: React.Key[];
   };
@@ -90,6 +93,8 @@ const getNewChild = (
     activeKey,
     openMotion,
     expandIcon,
+    classNames: collapseClassNames,
+    styles,
   } = props;
 
   const key = child.key || String(index);
@@ -122,6 +127,8 @@ const getNewChild = (
     panelKey: key,
     header,
     headerClass,
+    classNames: collapseClassNames,
+    styles,
     isActive,
     prefixCls,
     destroyInactivePanel: childDestroyInactivePanel ?? destroyInactivePanel,

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -37,6 +37,8 @@ export interface CollapseProps {
    * @since 3.6.0
    */
   items?: ItemType[];
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
 export type SemanticName = 'header' | 'title' | 'body' | 'icon';

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -871,12 +871,12 @@ describe('collapse', () => {
       const { container } = render(
         <Collapse
           activeKey={['1']}
+          styles={customStyles}
+          classNames={customClassnames}
           items={[
             {
               key: '1',
               label: 'title',
-              styles: customStyles,
-              classNames: customClassnames,
             },
           ]}
         />,
@@ -885,6 +885,7 @@ describe('collapse', () => {
       const bodyElement = container.querySelector('.rc-collapse-body') as HTMLElement;
       const titleElement = container.querySelector('.rc-collapse-title') as HTMLElement;
       const iconElement = container.querySelector('.rc-collapse-expand-icon') as HTMLElement;
+      console.log(container.innerHTML);
 
       // check classNames
       expect(headerElement.classList).toContain('custom-header');

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -885,7 +885,6 @@ describe('collapse', () => {
       const bodyElement = container.querySelector('.rc-collapse-body') as HTMLElement;
       const titleElement = container.querySelector('.rc-collapse-title') as HTMLElement;
       const iconElement = container.querySelector('.rc-collapse-expand-icon') as HTMLElement;
-      console.log(container.innerHTML);
 
       // check classNames
       expect(headerElement.classList).toContain('custom-header');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为折叠组件（Collapse）引入了更灵活的样式和类名自定义选项
	- 新增语义化的样式和类名定制能力，支持对头部、标题、正文和图标元素进行个性化设置

- **改进**
	- 扩展了组件的样式配置接口，提高了组件的可定制性
	- 允许通过 `classNames` 和 `styles` 属性全局定义组件样式

- **兼容性**
	- 保留了现有组件功能，不影响原有的控制流程
	- 为未来版本的样式定制做好准备

<!-- end of auto-generated comment: release notes by coderabbit.ai -->