### PR TITLE
feat: accessibility improvements

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -40,7 +40,7 @@
     }
 
     > .@{prefixCls}-header,
-    > :is(h1, h2, h3, h4, h5, h6) > .@{prefixCls}-header {
+    > .@{prefixCls}-header-wrapper > .@{prefixCls}-header {
       display: flex;
       align-items: center;
       line-height: 22px;
@@ -80,7 +80,7 @@
 
   & > &-item-disabled {
     > .@{prefixCls}-header,
-    > :is(h1,h2,h3,h4,h5,h6) > .@{prefixCls}-header {
+    > .@{prefixCls}-header-wrapper > .@{prefixCls}-header {
       cursor: not-allowed;
       color: #999;
       background-color: #f3f3f3;
@@ -111,7 +111,7 @@
 
   & > &-item-active {
     > .@{prefixCls}-header,
-    > :is(h1,h2,h3,h4,h5,h6) > .@{prefixCls}-header {
+    > .@{prefixCls}-header-wrapper > .@{prefixCls}-header {
       .arrow {
         position: relative;
         top: 2px;

--- a/assets/index.less
+++ b/assets/index.less
@@ -39,7 +39,8 @@
       border-top: none;
     }
 
-    > .@{prefixCls}-header {
+    > .@{prefixCls}-header,
+    > :is(h1, h2, h3, h4, h5, h6) > .@{prefixCls}-header {
       display: flex;
       align-items: center;
       line-height: 22px;
@@ -76,10 +77,14 @@
     }
   }
 
-  & > &-item-disabled > .@{prefixCls}-header {
-    cursor: not-allowed;
-    color: #999;
-    background-color: #f3f3f3;
+
+  & > &-item-disabled {
+    > .@{prefixCls}-header,
+    > :is(h1,h2,h3,h4,h5,h6) > .@{prefixCls}-header {
+      cursor: not-allowed;
+      color: #999;
+      background-color: #f3f3f3;
+    }
   }
 
   &-panel {
@@ -105,7 +110,8 @@
   }
 
   & > &-item-active {
-    > .@{prefixCls}-header {
+    > .@{prefixCls}-header,
+    > :is(h1,h2,h3,h4,h5,h6) > .@{prefixCls}-header {
       .arrow {
         position: relative;
         top: 2px;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "@babel/runtime": "^7.10.1",
     "@rc-component/util": "^1.0.1",
     "classnames": "2.x",
-    "rc-motion": "^2.3.4"
+    "rc-motion": "^2.3.4",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.1",

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -6,6 +6,7 @@ import useItems from './hooks/useItems';
 import type { CollapseProps } from './interface';
 import CollapsePanel from './Panel';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { v4 as uuid4 } from 'uuid';
 
 function getActiveKeysArray(activeKey: React.Key | React.Key[]) {
   let currentActiveKey = activeKey;
@@ -38,6 +39,8 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     headingLevel,
     id,
   } = props;
+
+  const [collapseId] = React.useState<string>(id ?? uuid4());
 
   const collapseClassName = classNames(prefixCls, className);
 
@@ -82,7 +85,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     styles,
     contentRole: panelContentRole,
     headingLevel,
-    id: id,
+    id: collapseId,
   });
 
   // ======================== Render ========================
@@ -93,7 +96,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
       style={style}
       role={accordion ? 'tablist' : undefined}
       {...pickAttrs(props, { aria: true, data: true })}
-      id={id}
+      id={collapseId}
     >
       {mergedChildren}
     </div>

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -35,7 +35,6 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     items,
     classNames: customizeClassNames,
     styles,
-    panelContentRole,
     headingLevel,
     id,
   } = props;
@@ -83,7 +82,6 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     activeKey,
     classNames: customizeClassNames,
     styles,
-    contentRole: panelContentRole,
     headingLevel,
     id: collapseId,
   });

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -34,6 +34,9 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     items,
     classNames: customizeClassNames,
     styles,
+    panelContentRole,
+    headingLevel,
+    id,
   } = props;
 
   const collapseClassName = classNames(prefixCls, className);
@@ -77,6 +80,9 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
     activeKey,
     classNames: customizeClassNames,
     styles,
+    contentRole: panelContentRole,
+    headingLevel,
+    id: id,
   });
 
   // ======================== Render ========================
@@ -87,6 +93,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
       style={style}
       role={accordion ? 'tablist' : undefined}
       {...pickAttrs(props, { aria: true, data: true })}
+      id={id}
     >
       {mergedChildren}
     </div>

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
 import KeyCode from '@rc-component/util/lib/KeyCode';
+import type { PropsWithChildren } from 'react';
 import React from 'react';
 import type { CollapsePanelProps } from './interface';
 import PanelContent from './PanelContent';
@@ -25,6 +26,9 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
     openMotion,
     destroyInactivePanel,
     children,
+    contentRole,
+    headingLevel,
+    id,
     ...resetProps
   } = props;
 
@@ -85,20 +89,33 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
     ...(['header', 'icon'].includes(collapsible) ? {} : collapsibleProps),
   };
 
+  const HeaderWrapper = ({ children: headerWrapperChildren }: PropsWithChildren) => {
+    if (!headingLevel) {
+      return <>{headerWrapperChildren}</>;
+    }
+    return React.createElement(headingLevel, { style: { all: 'unset' } }, headerWrapperChildren);
+  };
+
   // ======================== Render ========================
   return (
-    <div {...resetProps} ref={ref} className={collapsePanelClassNames}>
-      <div {...headerProps}>
-        {showArrow && iconNode}
-        <span
-          className={classNames(`${prefixCls}-title`, customizeClassNames?.title)}
-          style={styles?.title}
-          {...(collapsible === 'header' ? collapsibleProps : {})}
+    <div {...resetProps} ref={ref} className={collapsePanelClassNames} id={id}>
+      <HeaderWrapper>
+        <div
+          {...headerProps}
+          id={id ? `${id}__header` : undefined}
+          aria-controls={id ? `${id}__content` : undefined}
         >
-          {header}
-        </span>
-        {ifExtraExist && <div className={`${prefixCls}-extra`}>{extra}</div>}
-      </div>
+          {showArrow && iconNode}
+          <span
+            className={classNames(`${prefixCls}-title`, customizeClassNames?.title)}
+            style={styles?.title}
+            {...(collapsible === 'header' ? collapsibleProps : {})}
+          >
+            {header}
+          </span>
+          {ifExtraExist && <div className={`${prefixCls}-extra`}>{extra}</div>}
+        </div>
+      </HeaderWrapper>
       <CSSMotion
         visible={isActive}
         leavedClassName={`${prefixCls}-panel-hidden`}
@@ -110,6 +127,8 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
           return (
             <PanelContent
               ref={motionRef}
+              id={id ? `${id}__content` : undefined}
+              aria-labelledby={id ? `${id}__header` : undefined}
               prefixCls={prefixCls}
               className={motionClassName}
               classNames={customizeClassNames}
@@ -117,7 +136,7 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
               styles={styles}
               isActive={isActive}
               forceRender={forceRender}
-              role={accordion ? 'tabpanel' : void 0}
+              role={contentRole ? contentRole : accordion ? 'tabpanel' : void 0}
             >
               {children}
             </PanelContent>

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -26,7 +26,6 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
     openMotion,
     destroyInactivePanel,
     children,
-    contentRole,
     headingLevel,
     id,
     ...resetProps
@@ -92,8 +91,13 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
   const HeaderWrapper = ({ children: headerWrapperChildren }: PropsWithChildren) => {
     if (!headingLevel) {
       return <>{headerWrapperChildren}</>;
+    } else {
+      return (
+        <div className={`${prefixCls}-header-wrapper`} role="heading" aria-level={headingLevel}>
+          {headerWrapperChildren}
+        </div>
+      );
     }
-    return React.createElement(headingLevel, { style: { all: 'unset' } }, headerWrapperChildren);
   };
 
   // ======================== Render ========================
@@ -136,7 +140,7 @@ const CollapsePanel = React.forwardRef<HTMLDivElement, CollapsePanelProps>((prop
               styles={styles}
               isActive={isActive}
               forceRender={forceRender}
-              role={contentRole ? contentRole : accordion ? 'tabpanel' : void 0}
+              role={accordion ? 'tabpanel' : void 0}
             >
               {children}
             </PanelContent>

--- a/src/PanelContent.tsx
+++ b/src/PanelContent.tsx
@@ -16,6 +16,7 @@ const PanelContent = React.forwardRef<
     role,
     classNames: customizeClassNames,
     styles,
+    id,
   } = props;
 
   const [rendered, setRendered] = React.useState(isActive || forceRender);
@@ -33,6 +34,8 @@ const PanelContent = React.forwardRef<
   return (
     <div
       ref={ref}
+      id={id}
+      aria-labelledby={props['aria-labelledby']}
       className={classnames(
         `${prefixCls}-panel`,
         {

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -5,7 +5,15 @@ import CollapsePanel from '../Panel';
 
 type Props = Pick<
   CollapsePanelProps,
-  'prefixCls' | 'onItemClick' | 'openMotion' | 'expandIcon' | 'classNames' | 'styles'
+  | 'prefixCls'
+  | 'onItemClick'
+  | 'openMotion'
+  | 'expandIcon'
+  | 'classNames'
+  | 'styles'
+  | 'contentRole'
+  | 'headingLevel'
+  | 'id'
 > &
   Pick<CollapseProps, 'accordion' | 'collapsible' | 'destroyInactivePanel'> & {
     activeKey: React.Key[];
@@ -23,6 +31,9 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     expandIcon,
     classNames: collapseClassNames,
     styles,
+    contentRole,
+    headingLevel,
+    id,
   } = props;
 
   return items.map((item, index) => {
@@ -71,6 +82,9 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
         collapsible={mergeCollapsible}
         onItemClick={handleItemClick}
         destroyInactivePanel={mergeDestroyInactivePanel}
+        contentRole={contentRole}
+        headingLevel={headingLevel}
+        id={id ? `${id}__item-${index}` : undefined}
       >
         {children}
       </CollapsePanel>
@@ -99,6 +113,9 @@ const getNewChild = (
     expandIcon,
     classNames: collapseClassNames,
     styles,
+    contentRole,
+    headingLevel,
+    id,
   } = props;
 
   const key = child.key || String(index);
@@ -142,6 +159,9 @@ const getNewChild = (
     onItemClick: handleItemClick,
     expandIcon,
     collapsible: mergeCollapsible,
+    contentRole,
+    headingLevel,
+    id: id ? `${id}__item-${index}` : undefined,
   };
 
   // https://github.com/ant-design/ant-design/issues/20479

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -11,7 +11,6 @@ type Props = Pick<
   | 'expandIcon'
   | 'classNames'
   | 'styles'
-  | 'contentRole'
   | 'headingLevel'
   | 'id'
 > &
@@ -31,7 +30,6 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     expandIcon,
     classNames: collapseClassNames,
     styles,
-    contentRole,
     headingLevel,
     id,
   } = props;
@@ -82,7 +80,6 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
         collapsible={mergeCollapsible}
         onItemClick={handleItemClick}
         destroyInactivePanel={mergeDestroyInactivePanel}
-        contentRole={contentRole}
         headingLevel={headingLevel}
         id={id ? `${id}__item-${index}` : undefined}
       >
@@ -113,7 +110,6 @@ const getNewChild = (
     expandIcon,
     classNames: collapseClassNames,
     styles,
-    contentRole,
     headingLevel,
     id,
   } = props;
@@ -159,7 +155,6 @@ const getNewChild = (
     onItemClick: handleItemClick,
     expandIcon,
     collapsible: mergeCollapsible,
-    contentRole,
     headingLevel,
     id: id ? `${id}__item-${index}` : undefined,
   };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,6 +2,8 @@ import type { CSSMotionProps } from 'rc-motion';
 import type * as React from 'react';
 
 export type CollapsibleType = 'header' | 'icon' | 'disabled';
+export type HeadingLevelType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type PanelContentRoleType = 'region' | 'none';
 
 export interface ItemType
   extends Omit<
@@ -39,6 +41,9 @@ export interface CollapseProps {
   items?: ItemType[];
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+  headingLevel?: HeadingLevelType;
+  panelContentRole?: PanelContentRoleType;
+  id?: string;
 }
 
 export type SemanticName = 'header' | 'title' | 'body' | 'icon';
@@ -64,4 +69,6 @@ export interface CollapsePanelProps extends React.DOMAttributes<HTMLDivElement> 
   role?: string;
   collapsible?: CollapsibleType;
   children?: React.ReactNode;
+  contentRole?: PanelContentRoleType;
+  headingLevel?: HeadingLevelType;
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,8 +2,7 @@ import type { CSSMotionProps } from 'rc-motion';
 import type * as React from 'react';
 
 export type CollapsibleType = 'header' | 'icon' | 'disabled';
-export type HeadingLevelType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-export type PanelContentRoleType = 'region' | 'none';
+export type HeadingLevelType = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface ItemType
   extends Omit<
@@ -42,7 +41,6 @@ export interface CollapseProps {
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   headingLevel?: HeadingLevelType;
-  panelContentRole?: PanelContentRoleType;
   id?: string;
 }
 
@@ -69,6 +67,5 @@ export interface CollapsePanelProps extends React.DOMAttributes<HTMLDivElement> 
   role?: string;
   collapsible?: CollapsibleType;
   children?: React.ReactNode;
-  contentRole?: PanelContentRoleType;
   headingLevel?: HeadingLevelType;
 }

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -3,14 +3,18 @@
 exports[`collapse props items should work with nested 1`] = `
 <div
   class="rc-collapse"
+  id="collapse-test-id"
 >
   <div
     class="rc-collapse-item rc-collapse-item-disabled"
+    id="collapse-test-id__item-0"
   >
     <div
+      aria-controls="collapse-test-id__item-0__content"
       aria-disabled="true"
       aria-expanded="false"
       class="rc-collapse-header rc-collapse-collapsible-disabled"
+      id="collapse-test-id__item-0__header"
       role="button"
       tabindex="-1"
     >
@@ -30,11 +34,14 @@ exports[`collapse props items should work with nested 1`] = `
   </div>
   <div
     class="rc-collapse-item"
+    id="collapse-test-id__item-1"
   >
     <div
+      aria-controls="collapse-test-id__item-1__content"
       aria-disabled="false"
       aria-expanded="false"
       class="rc-collapse-header"
+      id="collapse-test-id__item-1__header"
       role="button"
       tabindex="0"
     >
@@ -61,11 +68,14 @@ exports[`collapse props items should work with nested 1`] = `
   </div>
   <div
     class="rc-collapse-item important"
+    id="collapse-test-id__item-2"
   >
     <div
+      aria-controls="collapse-test-id__item-2__content"
       aria-disabled="false"
       aria-expanded="false"
       class="rc-collapse-header"
+      id="collapse-test-id__item-2__header"
       role="button"
       tabindex="0"
     >
@@ -85,11 +95,14 @@ exports[`collapse props items should work with nested 1`] = `
   </div>
   <div
     class="rc-collapse-item"
+    id="collapse-test-id__item-3"
   >
     <div
+      aria-controls="collapse-test-id__item-3__content"
       aria-disabled="false"
       aria-expanded="false"
       class="rc-collapse-header"
+      id="collapse-test-id__item-3__header"
       role="button"
       tabindex="0"
     >

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -211,20 +211,41 @@ describe('collapse', () => {
   });
 
   describe('prop: id', () => {
-    const runIdTest = (element: any) => {
+    const runIdTest = (element: any, id?: string) => {
       const { container } = render(element);
-      expect(container.querySelector('#collapse-test-id')).toHaveClass('rc-collapse');
-      expect(container.querySelector('#collapse-test-id__item-0')).toHaveClass('rc-collapse-item');
+      let testId = id;
+      if (!testId) {
+        testId = container.querySelector('.rc-collapse').getAttribute('id');
+        expect(testId).toBeTruthy();
+      } else {
+        expect(container.querySelector(`[id="${testId}"]`)).toHaveClass('rc-collapse');
+      }
 
-      const header = container.querySelector('#collapse-test-id__item-0__header');
+      expect(container.querySelector(`[id="${testId}__item-0"]`)).toHaveClass('rc-collapse-item');
+
+      const header = container.querySelector(`[id="${testId}__item-0__header"]`);
       expect(header).toHaveClass('rc-collapse-header');
-      expect(header).toHaveAttribute('aria-controls', 'collapse-test-id__item-0__content');
+      expect(header).toHaveAttribute('aria-controls', `${testId}__item-0__content`);
+
       fireEvent.click(header);
       jest.runAllTimers();
-      const panelContent = container.querySelector('#collapse-test-id__item-0__content');
+
+      const panelContent = container.querySelector(`[id="${testId}__item-0__content"]`);
       expect(panelContent).toHaveClass('rc-collapse-panel');
-      expect(panelContent).toHaveAttribute('aria-labelledby', 'collapse-test-id__item-0__header');
+      expect(panelContent).toHaveAttribute('aria-labelledby', `${testId}__item-0__header`);
     };
+
+    it('applies default id to subcomponents - using composition', () => {
+      const element = (
+        <Collapse>
+          <Panel header="collapse 1" key="1">
+            first
+          </Panel>
+        </Collapse>
+      );
+
+      runIdTest(element);
+    });
 
     it('applies the passed id to subcomponents - using composition', () => {
       const element = (
@@ -233,6 +254,22 @@ describe('collapse', () => {
             first
           </Panel>
         </Collapse>
+      );
+
+      runIdTest(element, 'collapse-test-id');
+    });
+
+    it('applies default id to subcomponents - using items prop', () => {
+      const element = (
+        <Collapse
+          items={[
+            {
+              key: '1',
+              label: 'collapse 1',
+              children: 'first',
+            },
+          ]}
+        />
       );
 
       runIdTest(element);
@@ -252,7 +289,7 @@ describe('collapse', () => {
         />
       );
 
-      runIdTest(element);
+      runIdTest(element, 'collapse-test-id');
     });
   });
 
@@ -955,6 +992,7 @@ describe('collapse', () => {
     it('should work with nested', () => {
       const { container } = render(
         <Collapse
+          id="collapse-test-id"
           items={[
             ...items,
             {

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -3,12 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import React, { Fragment } from 'react';
 import Collapse, { Panel } from '../src/index';
-import type {
-  CollapseProps,
-  HeadingLevelType,
-  ItemType,
-  PanelContentRoleType,
-} from '../src/interface';
+import type { CollapseProps, HeadingLevelType, ItemType } from '../src/interface';
 
 describe('collapse', () => {
   let changeHook: jest.Mock<any, any> | null;
@@ -297,14 +292,13 @@ describe('collapse', () => {
     const runHeadingLevelTest = (element: any, headingLevel: HeadingLevelType) => {
       const { container } = render(element);
       const header = container.querySelector('.rc-collapse-header');
+      expect(header.parentElement.tagName).toEqual('DIV');
       if (headingLevel) {
-        expect(header.parentElement.tagName).toEqual(headingLevel.toUpperCase());
-      } else {
-        expect(header.parentElement.tagName).toEqual('DIV');
+        expect(Number(header.parentElement.getAttribute('aria-level'))).toEqual(headingLevel);
       }
     };
 
-    const headingElements: HeadingLevelType[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', undefined];
+    const headingElements: HeadingLevelType[] = [1, 2, 3, 4, 5, 6, undefined];
     test.each(headingElements)(
       'correctly creates element when headingLevel=%p - using composition',
       (headingLevel) => {
@@ -337,54 +331,6 @@ describe('collapse', () => {
         );
 
         runHeadingLevelTest(element, headingLevel);
-      },
-    );
-  });
-
-  describe('prop: panelContentRole', () => {
-    const runPanelContentRoleTest = (element: any, role: PanelContentRoleType) => {
-      const { container } = render(element);
-      const header = container.querySelector('.rc-collapse-header');
-      fireEvent.click(header);
-      const panel = container.querySelector('.rc-collapse-panel');
-      if (role) {
-        expect(panel.getAttribute('role')).toEqual(role);
-      } else {
-        expect(panel.getAttribute('role')).toEqual(null);
-      }
-    };
-
-    const panelRoles: PanelContentRoleType[] = ['region', 'none', undefined];
-    test.each(panelRoles)(
-      'correctly applies role when panelContentRole=%p - using composition',
-      (role) => {
-        const element = (
-          <Collapse panelContentRole={role}>
-            <Panel header="collapse 1" key="1">
-              first
-            </Panel>
-          </Collapse>
-        );
-        runPanelContentRoleTest(element, role);
-      },
-    );
-
-    test.each(panelRoles)(
-      'correctly applies role when panelContentRole=%p - using items prop',
-      (role) => {
-        const element = (
-          <Collapse
-            panelContentRole={role}
-            items={[
-              {
-                key: '1',
-                label: 'collapse 1',
-                children: 'first',
-              },
-            ]}
-          />
-        );
-        runPanelContentRoleTest(element, role);
       },
     );
   });


### PR DESCRIPTION
Implements 2/3 of the proposed changes here:
https://github.com/ant-design/ant-design/issues/53203

I did not implement the panel role change because there is already some logic around setting the panel role to "tabpanel" when in accordion mode, and the panel role = "region" is optional for a11y purposes.

- Adds optional `headingLevel` prop which will wrap the collapse header in a header element
- Adds a default id generated by uuid to the collapse which will be used to create ids for the child components in order to link the header and panel.
- Adds optional `id` prop which will override the default id mentioned above