### PR TITLE
fix: panel styles and classNames not working

### DIFF
--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -1,7 +1,8 @@
 import toArray from '@rc-component/util/lib/Children/toArray';
 import React from 'react';
-import type { CollapsePanelProps, CollapseProps, ItemType } from '../interface';
+import type { CollapsePanelProps, CollapseProps, ItemType, SemanticName } from '../interface';
 import CollapsePanel from '../Panel';
+import clsx from 'clsx';
 
 type Props = Pick<
   CollapsePanelProps,
@@ -59,17 +60,29 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
       isActive = activeKey.indexOf(key) > -1;
     }
 
+    const mergeClassNames: Partial<Record<SemanticName, string>> = {
+      ...collapseClassNames,
+      header: clsx(collapseClassNames?.header, classNames?.header),
+      body: clsx(collapseClassNames?.body, classNames?.body),
+    };
+
+    const mergeStyles: Partial<Record<SemanticName, React.CSSProperties>> = {
+      ...collapseStyles,
+      header: {
+        ...collapseStyles?.header,
+        ...styles?.header,
+      },
+      body: {
+        ...collapseStyles?.body,
+        ...styles?.body,
+      },
+    };
+
     return (
       <CollapsePanel
         {...restProps}
-        classNames={{
-          ...collapseClassNames,
-          ...classNames,
-        }}
-        styles={{
-          ...collapseStyles,
-          ...styles,
-        }}
+        classNames={mergeClassNames}
+        styles={mergeStyles}
         prefixCls={prefixCls}
         key={key}
         panelKey={key}

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -62,8 +62,14 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     return (
       <CollapsePanel
         {...restProps}
-        classNames={classNames || collapseClassNames}
-        styles={styles || collapseStyles}
+        classNames={{
+          ...collapseClassNames,
+          ...classNames,
+        }}
+        styles={{
+          ...collapseStyles,
+          ...styles,
+        }}
         prefixCls={prefixCls}
         key={key}
         panelKey={key}

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -22,7 +22,7 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     openMotion,
     expandIcon,
     classNames: collapseClassNames,
-    styles,
+    styles: collapseStyles,
   } = props;
 
   return items.map((item, index) => {
@@ -33,6 +33,8 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
       collapsible: rawCollapsible,
       onItemClick: rawOnItemClick,
       destroyOnHidden: rawDestroyOnHidden,
+      classNames,
+      styles,
       ...restProps
     } = item;
 
@@ -60,8 +62,8 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
     return (
       <CollapsePanel
         {...restProps}
-        classNames={collapseClassNames}
-        styles={styles}
+        classNames={classNames || collapseClassNames}
+        styles={styles || collapseStyles}
         prefixCls={prefixCls}
         key={key}
         panelKey={key}

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -64,6 +64,8 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
       ...collapseClassNames,
       header: clsx(collapseClassNames?.header, classNames?.header),
       body: clsx(collapseClassNames?.body, classNames?.body),
+      title: clsx(collapseClassNames?.title, classNames?.title),
+      icon: clsx(collapseClassNames?.icon, classNames?.icon),
     };
 
     const mergeStyles: Partial<Record<SemanticName, React.CSSProperties>> = {
@@ -75,6 +77,14 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
       body: {
         ...collapseStyles?.body,
         ...styles?.body,
+      },
+      title: {
+        ...collapseStyles?.title,
+        ...styles?.title,
+      },
+      icon: {
+        ...collapseStyles?.icon,
+        ...styles?.icon,
       },
     };
 

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -1,6 +1,6 @@
 import toArray from '@rc-component/util/lib/Children/toArray';
 import React from 'react';
-import type { CollapsePanelProps, CollapseProps, ItemType, SemanticName } from '../interface';
+import type { CollapsePanelProps, CollapseProps, ItemType } from '../interface';
 import CollapsePanel from '../Panel';
 import clsx from 'clsx';
 
@@ -11,6 +11,30 @@ type Props = Pick<
   Pick<CollapseProps, 'accordion' | 'collapsible' | 'destroyOnHidden'> & {
     activeKey: React.Key[];
   };
+
+function mergeSemantic<T>(src: T, tgt: T, mergeFn: (a: any, b: any) => any) {
+  if (!src || !tgt) {
+    return src || tgt;
+  }
+
+  const keys = Array.from(new Set([...Object.keys(src), ...Object.keys(tgt)]));
+  const result = {};
+  keys.forEach((key) => {
+    result[key] = mergeFn(src[key], tgt[key]);
+  });
+  return result;
+}
+
+function mergeSemanticClassNames<T>(src: T, tgt: T) {
+  return mergeSemantic(src, tgt, (a: string, b: string) => clsx(a, b));
+}
+
+function mergeSemanticStyles<T>(src: T, tgt: T) {
+  return mergeSemantic(src, tgt, (a: React.CSSProperties, b: React.CSSProperties) => ({
+    ...a,
+    ...b,
+  }));
+}
 
 const convertItemsToNodes = (items: ItemType[], props: Props) => {
   const {
@@ -60,39 +84,11 @@ const convertItemsToNodes = (items: ItemType[], props: Props) => {
       isActive = activeKey.indexOf(key) > -1;
     }
 
-    const mergeClassNames: Partial<Record<SemanticName, string>> = {
-      ...collapseClassNames,
-      header: clsx(collapseClassNames?.header, classNames?.header),
-      body: clsx(collapseClassNames?.body, classNames?.body),
-      title: clsx(collapseClassNames?.title, classNames?.title),
-      icon: clsx(collapseClassNames?.icon, classNames?.icon),
-    };
-
-    const mergeStyles: Partial<Record<SemanticName, React.CSSProperties>> = {
-      ...collapseStyles,
-      header: {
-        ...collapseStyles?.header,
-        ...styles?.header,
-      },
-      body: {
-        ...collapseStyles?.body,
-        ...styles?.body,
-      },
-      title: {
-        ...collapseStyles?.title,
-        ...styles?.title,
-      },
-      icon: {
-        ...collapseStyles?.icon,
-        ...styles?.icon,
-      },
-    };
-
     return (
       <CollapsePanel
         {...restProps}
-        classNames={mergeClassNames}
-        styles={mergeStyles}
+        classNames={mergeSemanticClassNames(collapseClassNames, classNames)}
+        styles={mergeSemanticStyles(collapseStyles, styles)}
         prefixCls={prefixCls}
         key={key}
         panelKey={key}

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -898,5 +898,59 @@ describe('collapse', () => {
       expect(titleElement.style.color).toBe('green');
       expect(iconElement.style.color).toBe('yellow');
     });
+
+    it('should support styles and classNames in panel', () => {
+      const customStyles = {
+        header: { color: 'red' },
+        body: { color: 'blue' },
+        title: { color: 'green' },
+        icon: { color: 'yellow' },
+      };
+      const customClassnames = {
+        header: 'custom-header',
+        body: 'custom-body',
+      };
+
+      const { container } = render(
+        <Collapse
+          activeKey={['1']}
+          styles={customStyles}
+          classNames={customClassnames}
+          items={[
+            {
+              key: '1',
+              styles: {
+                header: {
+                  color: 'blue',
+                  fontSize: 20,
+                },
+                body: {
+                  fontSize: 20,
+                },
+              },
+              classNames: {
+                header: 'custom-header-panel',
+                body: 'custom-body-panel',
+              },
+              label: 'title',
+            },
+          ]}
+        />,
+      );
+      const headerElement = container.querySelector('.rc-collapse-header') as HTMLElement;
+      const bodyElement = container.querySelector('.rc-collapse-body') as HTMLElement;
+
+      // check classNames
+      expect(headerElement.classList).toContain('custom-header');
+      expect(headerElement.classList).toContain('custom-header-panel');
+      expect(bodyElement.classList).toContain('custom-body');
+      expect(bodyElement.classList).toContain('custom-body-panel');
+
+      // check styles
+      expect(headerElement.style.color).toBe('blue');
+      expect(headerElement.style.fontSize).toBe('20px');
+      expect(bodyElement.style.color).toBe('blue');
+      expect(bodyElement.style.fontSize).toBe('20px');
+    });
   });
 });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -927,6 +927,12 @@ describe('collapse', () => {
                 body: {
                   fontSize: 20,
                 },
+                title: {
+                  color: 'red',
+                },
+                icon: {
+                  color: 'blue',
+                },
               },
               classNames: {
                 header: 'custom-header-panel',
@@ -939,6 +945,8 @@ describe('collapse', () => {
       );
       const headerElement = container.querySelector('.rc-collapse-header') as HTMLElement;
       const bodyElement = container.querySelector('.rc-collapse-body') as HTMLElement;
+      const titleElement = container.querySelector('.rc-collapse-title') as HTMLElement;
+      const iconElement = container.querySelector('.rc-collapse-expand-icon') as HTMLElement;
 
       // check classNames
       expect(headerElement.classList).toContain('custom-header');
@@ -947,10 +955,10 @@ describe('collapse', () => {
       expect(bodyElement.classList).toContain('custom-body-panel');
 
       // check styles
-      expect(headerElement.style.color).toBe('blue');
-      expect(headerElement.style.fontSize).toBe('20px');
-      expect(bodyElement.style.color).toBe('blue');
-      expect(bodyElement.style.fontSize).toBe('20px');
+      expect(headerElement).toHaveStyle({ color: 'blue', fontSize: '20px' });
+      expect(bodyElement).toHaveStyle({ color: 'blue', fontSize: '20px' });
+      expect(titleElement).toHaveStyle({ color: 'red' });
+      expect(iconElement).toHaveStyle({ color: 'blue' });
     });
   });
 });


### PR DESCRIPTION
If the panel is set to styles or classNames, use it's properties, otherwise use collpase's styles or classNames.

fix https://github.com/ant-design/ant-design/issues/55916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持为单个面板项提供头部与主体的样式与类名覆盖，允许按项细粒度定制。

* **改进**
  * 渲染时会合并全局与每项的样式/类名，确保局部覆盖生效且未提供覆盖时保持兼容。

* **测试**
  * 新增测试验证每项层级的样式与类名覆盖及其与全局配置的组合生效情况。

* **注意**
  * 对外公开接口未发生变更。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->