### PR TITLE
Avoid rc deep imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ const disabledTypeScriptRules = {
 
 module.exports = {
   ...base,
-  overrides: base.overrides.map((override) => ({
+  overrides: (base.overrides || []).map((override) => ({
     ...override,
     rules: {
       ...override.rules,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,28 @@
 const base = require('@umijs/fabric/dist/eslint');
 
+const disabledTypeScriptRules = {
+  '@typescript-eslint/ban-types': 0,
+  '@typescript-eslint/no-parameter-properties': 0,
+  '@typescript-eslint/no-throw-literal': 0,
+  '@typescript-eslint/type-annotation-spacing': 0,
+};
+
 module.exports = {
   ...base,
+  overrides: base.overrides.map((override) => ({
+    ...override,
+    rules: {
+      ...override.rules,
+      ...disabledTypeScriptRules,
+    },
+  })),
   rules: {
     ...base.rules,
     'no-template-curly-in-string': 0,
     'prefer-promise-reject-errors': 0,
     'react/no-array-index-key': 0,
     'react/sort-comp': 0,
+    ...disabledTypeScriptRules,
     '@typescript-eslint/no-explicit-any': 0,
     'jsx-a11y/role-supports-aria-props': 0,
     'jsx-a11y/label-has-associated-control': 0,

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "@rc-component/motion": "^1.1.4",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.4",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^16.3.0",

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -1,11 +1,10 @@
 import { clsx } from 'clsx';
 import { useControlledState, useEvent } from '@rc-component/util';
-import warning from '@rc-component/util/lib/warning';
+import { pickAttrs, warning } from '@rc-component/util';
 import React from 'react';
 import useItems from './hooks/useItems';
 import type { CollapseProps } from './interface';
 import CollapsePanel from './Panel';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
 function getActiveKeysArray(activeKey: React.Key | React.Key[]): React.Key[] {
   let currentActiveKey = activeKey;

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -1,6 +1,5 @@
 import { clsx } from 'clsx';
-import { useControlledState, useEvent } from '@rc-component/util';
-import { pickAttrs, warning } from '@rc-component/util';
+import { pickAttrs, useControlledState, useEvent, warning } from '@rc-component/util';
 import React from 'react';
 import useItems from './hooks/useItems';
 import type { CollapseProps } from './interface';

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import CSSMotion from '@rc-component/motion';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React from 'react';
 import type { CollapsePanelProps } from './interface';
 import PanelContent from './PanelContent';

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -1,4 +1,4 @@
-import toArray from '@rc-component/util/lib/Children/toArray';
+import { toArray } from '@rc-component/util';
 import React from 'react';
 import type { CollapsePanelProps, CollapseProps, ItemType } from '../interface';
 import CollapsePanel from '../Panel';

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -1,6 +1,6 @@
 import type { RenderResult } from '@testing-library/react';
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import React, { Fragment } from 'react';
 import Collapse, { Panel } from '../src/index';
 import type { CollapseProps, ItemType } from '../src/interface';


### PR DESCRIPTION
## 调整内容

- 将项目内对 `@rc-component/util/lib/*` 的引用调整为从 `@rc-component/util` 根入口导入。
- 升级 `@rc-component/util` 到 `^1.11.1`，升级 `@rc-component/father-plugin` 到 `^2.2.0`。
- 为当前 lint 依赖解析结果补充旧 `@typescript-eslint` 规则的关闭配置，避免升级后 lint 报 rule not found。

## 背景

为了避免 rc 包之间依赖 `es` / `lib` 构建产物内部路径，统一改为依赖公开根入口。后续深路径限制由 `@rc-component/father-plugin` 统一处理。

## 验证

- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级了依赖版本，提升代码库的稳定性和兼容性。
  * 优化了 ESLint 配置，增强代码质量检查。

* **Refactor**
  * 调整了模块导入结构，改进代码组织方式。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/collapse/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->